### PR TITLE
Fix Drupal 9 compatibility

### DIFF
--- a/features/sooper-fonts/fonts-theme-settings.inc
+++ b/features/sooper-fonts/fonts-theme-settings.inc
@@ -115,7 +115,7 @@ function dxpr_theme_local_webfonts() {
   $theme_chain = ['dxpr_theme'];
   $fonts = [];
   foreach ($theme_chain as $theme) {
-    foreach (file_scan_directory(drupal_get_path('theme', $theme) . '/fonts', '/.css/i') as $file) {
+    foreach (\Drupal::service('file_system')->scanDirectory(drupal_get_path('theme', $theme) . '/fonts', '/.css/i') as $file) {
       $font_path = str_replace(drupal_get_path('theme', $theme), '', $file->uri);
       $css = file_get_contents($file->uri);
       if ($css) {


### PR DESCRIPTION
I've used the [Upgrade Status](https://www.drupal.org/project/upgrade_status), and found only 1 error for a deprecated function (`file_scan_directory()`)
![image](https://user-images.githubusercontent.com/7836180/83509257-70712100-a4cb-11ea-9a18-dbb328c37491.png)

I didn't actually test the theme in Drupal 9 because it depends on the [Bootstrap theme](https://www.drupal.org/project/bootstrap) which is still not ready for Drupal 9.