### PR TITLE
Optimized theme settings form for dr7 #25

### DIFF
--- a/dxpr_theme_callbacks.inc
+++ b/dxpr_theme_callbacks.inc
@@ -102,7 +102,7 @@ function dxpr_theme_css_cache_build($theme) {
   global $base_path, $base_theme_info;
   $files_path = variable_get('file_public_path', conf_path() . '/files');
 
-  $dxpr_theme_css_file = $files_path . '/dxpr-theme-themesettings-' . $theme . '.css';
+  $dxpr_theme_css_file = _dxpr_theme_css_cache_file($theme);
   // Construct CSS file:
   $CSS = '';
   // Load DXPR Theme colors palette.


### PR DESCRIPTION
It turned out that Drupal 7 has a slightly different queue for calling the handler functions. The order of the system_theme_settings_submit function in the queue cannot be overwritten in a theme using hooks. Hooks
hook_exit, hook_page_alter (with post_render) cannot be applied (because for settings form use another current theme and this is theme not module). Had to use register_shutdown_function function. So Drupal 7 version theme also is  working fine now.
fixes #25 