### PR TITLE
Fixed Theme settings performance update breaks installation profile #58

### DIFF
--- a/dxpr_theme_callbacks.inc
+++ b/dxpr_theme_callbacks.inc
@@ -8,6 +8,20 @@
 use Drupal\Core\Asset\CssOptimizer;
 use Drupal\Core\File\FileSystemInterface;
 
+
+/**
+ * Helper function returns path of css cache file.
+ *
+ * @param string $path
+ *   A path relative to the Drupal root or to the public files directory, or
+ *   a stream wrapper URI.
+ *
+ * @return string
+ *   A valid path of css cache file.
+ */
+function _dxpr_theme_css_cache_file($theme) {
+  return 'public://dxpr_theme/css/themesettings-' . $theme . '.css';
+}
 /**
  * Write css files for the color settings.
  *

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -379,16 +379,3 @@ function dxpr_theme_form_system_theme_settings_after_submit(&$form, &$form_state
   dxpr_theme_css_cache_build($subject_theme);
 }
 
-/**
- * Helper function returns path of css cache file.
- *
- * @param string $path
- *   A path relative to the Drupal root or to the public files directory, or
- *   a stream wrapper URI.
- *
- * @return string
- *   A valid path of css cache file.
- */
-function _dxpr_theme_css_cache_file($theme) {
-  return 'public://dxpr_theme/css/themesettings-' . $theme . '.css';
-}


### PR DESCRIPTION
In order to fix the error, the function was moved to a file that is always included dxpr_theme_callbacks.inc. Not removed because in the future can be problem to find the path of cache file. 

fixes #58