### PR TITLE
remove template that was only here to override it from bootstrap base…

### DIFF
--- a/templates/block--system-menu-block.html.twig
+++ b/templates/block--system-menu-block.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation for a menu block.
+ * Theme override to display a block.
  *
  * Available variables:
  * - plugin_id: The ID of the block implementation.
@@ -12,25 +12,17 @@
  *   - provider: The module or other provider that provided this block plugin.
  *   - Block plugin specific settings will also be stored here.
  * - content: The content of this block.
- * - attributes: HTML attributes for the containing element.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
  *   - id: A valid HTML ID and guaranteed unique.
- * - title_attributes: HTML attributes for the title element.
- * - content_attributes: HTML attributes for the content element.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
  * - title_prefix: Additional output populated by modules, intended to be
  *   displayed in front of the main title tag that appears in the template.
  * - title_suffix: Additional output populated by modules, intended to be
  *   displayed after the main title tag that appears in the template.
  *
- * Headings should be used on navigation menus that consistently appear on
- * multiple pages. When this menu block's label is configured to not be
- * displayed, it is automatically made invisible using the 'visually-hidden' CSS
- * class, which still keeps it visible for screen-readers and assistive
- * technology. Headings allow screen-reader and keyboard only users to navigate
- * to or skip the links.
- * See http://juicystudio.com/article/screen-readers-display-none.php and
- * http://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
- *
- * @ingroup templates
+ * @see template_preprocess_block()
  */
 #}
 {% set designRegions = [] %}
@@ -54,6 +46,7 @@
     theme.settings.title_well and region in designRegions ? theme.settings.title_well,
   ]
 %}
+
 <section{{ attributes.addClass(classes) }}>
   {{ title_prefix }}
   {% if theme.settings.title_sticker and region in designRegions %}


### PR DESCRIPTION
… theme, add template to override it from bootstrap4 base theme. the added template is just a clone of the regular block template

fixes #131 