### PR TITLE
standardize all theme paths to  and  depending on what is required.

### DIFF
--- a/includes/dxpr_theme_js_alter.inc
+++ b/includes/dxpr_theme_js_alter.inc
@@ -8,13 +8,18 @@
  * Implements hook_js_alter().
  */
 function dxpr_theme_js_alter(&$js) {
-  $theme_path = drupal_get_path('theme', 'dxpr_theme') . '/';
+  global $theme;
+  // Global $theme_path variable is buggy so we create our own vars
+  // @see https://github.com/dxpr/dxpr_theme/issues/170
+  $theme_path_active = drupal_get_path('theme', $theme);
+  $theme_path_base = drupal_get_path('theme', 'dxpr_theme');
+  
   // Add Bootstrap settings.
   $js['settings']['data'][]['dxpr_theme'] = array(
-    'dxpr_themePath' => $theme_path,
+    'dxpr_themePath' => $theme_path_base . '/',
   );
   // Override color module color.js because it's broken when bootstrap theme is loaded.
   if (isset($js['modules/color/color.js']['data'])) {
-    $js['modules/color/color.js']['data'] = $theme_path . 'js/minified/color.min.js';
+    $js['modules/color/color.js']['data'] = $theme_path_base . '/js/minified/color.min.js';
   }
 }

--- a/includes/dxpr_theme_menu_link.inc
+++ b/includes/dxpr_theme_menu_link.inc
@@ -20,14 +20,18 @@
  */
 function dxpr_theme_menu_link(array $variables) {
   global $theme;
-  $current_theme_path = drupal_get_path('theme', $theme);
+  // Global $theme_path variable is buggy so we create our own vars
+  // @see https://github.com/dxpr/dxpr_theme/issues/170
+  $theme_path_active = drupal_get_path('theme', $theme);
+  $theme_path_base = drupal_get_path('theme', 'dxpr_theme');
+  
   $element = $variables['element'];
   $sub_menu = '';
   $careticon = '';
 
   if ($element['#below']) {
     // below file should be loaded here after properly separating all mulitilevel menu code from dxpr-theme-header.js
-    // drupal_add_js($current_theme_path . '/js/minified/dxpr-theme-multilevel-mobile-nav.min.js');
+    // drupal_add_js($theme_path_base . '/js/minified/dxpr-theme-multilevel-mobile-nav.min.js');
 
     // Prevent dropdown functions from being added to management menu so it
     // does not affect the navbar module.

--- a/includes/dxpr_theme_preprocess_block.inc
+++ b/includes/dxpr_theme_preprocess_block.inc
@@ -8,13 +8,15 @@
  * Implements template_preprocess_block()
  */
 function dxpr_theme_preprocess_block(&$vars) {
-  global $theme, $theme_path;
-  // There is a bug that makes global variable $theme_path return the base theme
-  // path instead of the active theme path, hence the custom variable below.
-  $theme_path_custom = drupal_get_path('theme', $theme);
+  global $theme;
+  // Global $theme_path variable is buggy so we create our own vars
+  // @see https://github.com/dxpr/dxpr_theme/issues/170
+  $theme_path_active = drupal_get_path('theme', $theme);
+  $theme_path_base = drupal_get_path('theme', 'dxpr_theme');
+
   if ($vars['block_html_id'] == 'block-dxpr-theme-helper-full-screen-search') {
-    drupal_add_css($theme_path_custom . '/css/components/dxpr-theme-full-screen-search.css', array('group' => CSS_THEME));
-    drupal_add_js($theme_path . '/js/minified/dxpr-theme-full-screen-search.min.js');
+    drupal_add_css($theme_path_active . '/css/components/dxpr-theme-full-screen-search.css', array('group' => CSS_THEME));
+    drupal_add_js($theme_path_base . '/js/minified/dxpr-theme-full-screen-search.min.js');
   }
   if ((theme_get_setting('block_design_regions'))
     && in_array($vars['block']->region, array_filter(theme_get_setting('block_design_regions')))) {

--- a/includes/dxpr_theme_preprocess_breadcrumb.inc
+++ b/includes/dxpr_theme_preprocess_breadcrumb.inc
@@ -8,12 +8,14 @@
  * Override or insert variables into the page template for HTML output.
  */
 function dxpr_theme_preprocess_breadcrumb(&$vars) {
-  global $theme, $theme_path;
-  // There is a bug that makes global variable $theme_path return the base theme
-  // path instead of the active theme path, hence the custom variable below.
-  $theme_path_custom = drupal_get_path('theme', $theme);
+  global $theme;
+  // Global $theme_path variable is buggy so we create our own vars
+  // @see https://github.com/dxpr/dxpr_theme/issues/170
+  $theme_path_active = drupal_get_path('theme', $theme);
+  $theme_path_base = drupal_get_path('theme', 'dxpr_theme');
+
   if ($vars['breadcrumb']) {
-    drupal_add_css($theme_path_custom . '/css/vendor-extensions/drupal-breadcrumbs.css', array('group' => CSS_THEME));
-    drupal_add_js($theme_path . '/js/minified/dxpr-theme-breadcrumbs.min.js');
+    drupal_add_css($theme_path_active . '/css/vendor-extensions/drupal-breadcrumbs.css', array('group' => CSS_THEME));
+    drupal_add_js($theme_path_base . '/js/minified/dxpr-theme-breadcrumbs.min.js');
   }
 }

--- a/includes/dxpr_theme_preprocess_comment_wrapper.inc
+++ b/includes/dxpr_theme_preprocess_comment_wrapper.inc
@@ -8,6 +8,11 @@
  * Override or insert variables into the page template for HTML output.
  */
 function dxpr_theme_preprocess_comment_wrapper(&$vars) {
-  global $theme_path;
-  drupal_add_css($theme_path . '/css/vendor-extensions/drupal-comments.css', array('group' => CSS_THEME));
+  global $theme;
+  // Global $theme_path variable is buggy so we create our own vars
+  // @see https://github.com/dxpr/dxpr_theme/issues/170
+  $theme_path_active = drupal_get_path('theme', $theme);
+  $theme_path_base = drupal_get_path('theme', 'dxpr_theme');
+
+  drupal_add_css($theme_path_active . '/css/vendor-extensions/drupal-comments.css', array('group' => CSS_THEME));
 }

--- a/includes/dxpr_theme_preprocess_html.inc
+++ b/includes/dxpr_theme_preprocess_html.inc
@@ -9,19 +9,23 @@
  */
 function dxpr_theme_preprocess_html(&$vars) {
   global $theme;
+  // Global $theme_path variable is buggy so we create our own vars
+  // @see https://github.com/dxpr/dxpr_theme/issues/170
+  $theme_path_active = drupal_get_path('theme', $theme);
+  $theme_path_base = drupal_get_path('theme', 'dxpr_theme');
+
   // If bootstrap basetheme is not loading bootstrap from CDN load it locally
   // This is default behavior starting from DXPR Theme 8.x-1.1.3 and 7.x-2.7.3.
   $bootstrap_cdn = theme_get_setting('cdn_provider');
   if (!$bootstrap_cdn) {
-    $path = drupal_get_path('theme', 'dxpr_theme');
     drupal_add_js(
-      $path . '/vendor/bootstrap3/js/bootstrap.min.js', array(
+      $theme_path_base . '/vendor/bootstrap3/js/bootstrap.min.js', array(
         'group' => JS_THEME,
         'every_page' => TRUE,
         'weight' => -18,
       ));
     drupal_add_css(
-      $path . '/vendor/bootstrap3/css/bootstrap.min.css', array(
+      $theme_path_base . '/vendor/bootstrap3/css/bootstrap.min.css', array(
         'group' => CSS_DEFAULT,
         'media' => 'all',
         'every_page' => TRUE,

--- a/includes/dxpr_theme_preprocess_node.inc
+++ b/includes/dxpr_theme_preprocess_node.inc
@@ -8,10 +8,12 @@
  * Implements template_preprocess_node()
  */
 function dxpr_theme_preprocess_node(&$vars) {
-  global $theme, $theme_path;
-  // There is a bug that makes global variable $theme_path return the base theme
-  // path instead of the active theme path, hence the custom variable below.
-  $theme_path_custom = drupal_get_path('theme', $theme);
+  global $theme;
+  // Global $theme_path variable is buggy so we create our own vars
+  // @see https://github.com/dxpr/dxpr_theme/issues/170
+  $theme_path_active = drupal_get_path('theme', $theme);
+  $theme_path_base = drupal_get_path('theme', 'dxpr_theme');
+
   // ALL NODES
   // remove "add comment link. it's silly because the comment form will be right there in our theme".
   if (isset($vars['content']['links']['comment'])) {
@@ -76,12 +78,11 @@ function dxpr_theme_preprocess_node(&$vars) {
       $lightbox = TRUE;
     }
     if ($lightbox) {
-      $path = drupal_get_path('theme', 'dxpr_theme');
-      drupal_add_js($path . '/vendor/ilightbox/js/jquery.requestAnimationFrame.js');
-      drupal_add_js($path . '/vendor/ilightbox/js/jquery.mousewheel.js');
-      drupal_add_js($path . '/vendor/ilightbox/js/ilightbox.min.js');
-      drupal_add_js($path . '/js/minified/dxpr-theme-ilightbox.min.js');
-      drupal_add_css($path . '/vendor/ilightbox/css/ilightbox.css');
+      drupal_add_js($theme_path_base . '/vendor/ilightbox/js/jquery.requestAnimationFrame.js');
+      drupal_add_js($theme_path_base . '/vendor/ilightbox/js/jquery.mousewheel.js');
+      drupal_add_js($theme_path_base . '/vendor/ilightbox/js/ilightbox.min.js');
+      drupal_add_js($theme_path_base . '/js/minified/dxpr-theme-ilightbox.min.js');
+      drupal_add_css($theme_path_base . '/vendor/ilightbox/css/ilightbox.css');
     }
   }
 

--- a/includes/dxpr_theme_preprocess_page.inc
+++ b/includes/dxpr_theme_preprocess_page.inc
@@ -8,7 +8,12 @@
  * Implements template_preprocess_page().
  */
 function dxpr_theme_preprocess_page(&$vars) {
-  global $theme, $theme_path, $user;
+  global $theme, $user;
+  // Global $theme_path variable is buggy so we create our own vars
+  // @see https://github.com/dxpr/dxpr_theme/issues/170
+  $theme_path_active = drupal_get_path('theme', $theme);
+  $theme_path_base = drupal_get_path('theme', 'dxpr_theme');
+
   if ($hidden_regions = theme_get_setting('hidden_regions')) {
     $hidden_regions = array_filter(theme_get_setting('hidden_regions'));
   }
@@ -282,9 +287,8 @@ function dxpr_theme_preprocess_page(&$vars) {
     $page_css[] = '/css/components/dxpr-theme-header--top.css';
     $page_css[] = '/css/components/dxpr-theme-header--side.css';
     $page_css[] = '/css/components/dxpr-theme-header--mobile.css';
-    $path = drupal_get_path('theme', 'dxpr_theme');
-    drupal_add_js($path . '/js/minified/dxpr-theme-multilevel-mobile-nav.min.js');
-    drupal_add_js($path . '/js/minified/dxpr-theme-header.min.js');
+    drupal_add_js($theme_path_base . '/js/minified/dxpr-theme-multilevel-mobile-nav.min.js');
+    drupal_add_js($theme_path_base . '/js/minified/dxpr-theme-header.min.js');
   }
   if (!empty($vars['page']['footer'])) {
     $page_css[] = '/css/base/footer-menu.css';
@@ -294,7 +298,7 @@ function dxpr_theme_preprocess_page(&$vars) {
     $page_css[] = '/css/vendor-extensions/drupal-pager.css';
   }
   foreach ($page_css as $css) {
-    drupal_add_css($theme_path . $css, array('group' => CSS_THEME, 'every_page' => TRUE));
+    drupal_add_css($theme_path_active . $css, array('group' => CSS_THEME, 'every_page' => TRUE));
   }
   // CSS that is only relevant in backend interfaces (field, views config, node forms, etc.)
   $auth_css = array(
@@ -303,7 +307,7 @@ function dxpr_theme_preprocess_page(&$vars) {
   );
   if ($user->uid > 0) {
     foreach ($auth_css as $css) {
-      drupal_add_css($theme_path . $css, array('group' => CSS_THEME, 'every_page' => TRUE));
+      drupal_add_css($theme_path_active . $css, array('group' => CSS_THEME, 'every_page' => TRUE));
     }
 
   }

--- a/includes/dxpr_theme_preprocess_pager_link.inc
+++ b/includes/dxpr_theme_preprocess_pager_link.inc
@@ -8,9 +8,11 @@
  * Override or insert variables into the page template for HTML output.
  */
 function dxpr_theme_preprocess_pager_link(&$vars) {
-  global $theme, $theme_path;
-  // There is a bug that makes global variable $theme_path return the base theme
-  // path instead of the active theme path, hence the custom variable below.
-  $theme_path_custom = drupal_get_path('theme', $theme);
-  drupal_add_css($theme_path_custom . '/css/vendor-extensions/drupal-pager.css', array('group' => CSS_THEME));
+  global $theme;
+  // Global $theme_path variable is buggy so we create our own vars
+  // @see https://github.com/dxpr/dxpr_theme/issues/170
+  $theme_path_active = drupal_get_path('theme', $theme);
+  $theme_path_base = drupal_get_path('theme', 'dxpr_theme');
+
+  drupal_add_css($theme_path_active . '/css/vendor-extensions/drupal-pager.css', array('group' => CSS_THEME));
 }

--- a/includes/dxpr_theme_preprocess_webform_form.inc
+++ b/includes/dxpr_theme_preprocess_webform_form.inc
@@ -5,8 +5,10 @@
  */
 function dxpr_theme_preprocess_webform_form(&$vars) {
   global $theme;
-  // There is a bug that makes global variable $theme_path return the base theme
-  // path instead of the active theme path, hence the custom variable below
-  $theme_path_custom = drupal_get_path('theme', $theme);
-  drupal_add_css($theme_path_custom . '/css/vendor-extensions/drupal-webform.css', array('group' => CSS_THEME));
+  // Global $theme_path variable is buggy so we create our own vars
+  // @see https://github.com/dxpr/dxpr_theme/issues/170
+  $theme_path_active = drupal_get_path('theme', $theme);
+  $theme_path_base = drupal_get_path('theme', 'dxpr_theme');
+
+  drupal_add_css($theme_path_active . '/css/vendor-extensions/drupal-webform.css', array('group' => CSS_THEME));
 }

--- a/template.php
+++ b/template.php
@@ -52,7 +52,7 @@ EOT;
  */
 function _dxpr_theme_color_html_alter(&$vars) {
   global $theme_key;
-  $theme_path = drupal_get_path('theme', $theme_key);
+  $theme_path_key = drupal_get_path('theme', $theme_key);
   // Override stylesheets.
   $color_paths = variable_get('color_' . $theme_key . '_stylesheets', array());
   if (!empty($color_paths)) {
@@ -61,7 +61,7 @@ function _dxpr_theme_color_html_alter(&$vars) {
       $color_paths_map[drupal_basename($color_path)] = $color_path;
     }
     foreach ($vars['css'] as $old_path => $data) {
-      if (strpos($old_path, $theme_path) === 0 && isset($color_paths_map[drupal_basename($old_path)])) {
+      if (strpos($old_path, $theme_path_key) === 0 && isset($color_paths_map[drupal_basename($old_path)])) {
         $vars['css'][$old_path]['data'] = $color_paths_map[drupal_basename($old_path)];
       }
     }


### PR DESCRIPTION
## Linked issues

- fixes #170 

## Solution

Remove all use of the buggy $theme_path variable. To prevent further confusion standardize all use of paths pointing to themes to use either the $theme_path_base, $theme_path_active, or $theme_path_key variables.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My code follows the coding standards and style of this project.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
