### PR TITLE
Neslee/2.x/#148 fix numbering in search

### DIFF
--- a/templates/item-list--search-results.html.twig
+++ b/templates/item-list--search-results.html.twig
@@ -22,7 +22,6 @@
 #}
 {%
   set classes = [
-    'search-results',
     context.plugin ~ '-results',
   ]
 %}


### PR DESCRIPTION
## Linked issues

- #148 

## Solution

1. Adding item list search result template from classy
2. Removing unnecessary class search-result which is overriding ol tag to force use list-style-type property

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
