### PR TITLE
restore loading script for local bootstrap files

### DIFF
--- a/dxpr_theme.theme
+++ b/dxpr_theme.theme
@@ -57,7 +57,13 @@ function dxpr_theme_preprocess(&$variables, $hook, $info) {
  * See the html.html.twig template for the list of variables.
  */
 function dxpr_theme_preprocess_html(&$variables) {
-
+  // If bootstrap basetheme is not loading bootstrap from CDN load it locally
+  // This is default behavior starting from DXPR Theme 8.x-1.1.3 and 7.x-2.7.3.
+  $bootstrap_cdn = theme_get_setting('cdn_provider');
+  if (!$bootstrap_cdn) {
+    $variables['#attached']['library'][] = 'dxpr_theme/bootstrap3';
+  }
+  
   if ($node = \Drupal::routeMatch()->getParameter('node')) {
     $variables['node'] = $node;
   }


### PR DESCRIPTION
## Linked issues

- #214 

## Solution

Restore code that was removed by accident, removal was intended for 2.x branch. Restoring this code brings back bootstrap 3 assets when cdn_provider is set to empty string.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My code follows the coding standards and style of this project.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
