### PR TITLE
remove theme settings loader function that was intended for 2.x

### DIFF
--- a/dxpr_theme.theme
+++ b/dxpr_theme.theme
@@ -40,16 +40,6 @@ function dxpr_theme_library_info_alter(&$libraries, $extension) {
 }
 
 /**
- * Prepares variables for the all templates. Theme settings.
- */
-function dxpr_theme_preprocess(&$variables, $hook, $info) {
-  $theme = \Drupal::theme()
-    ->getActiveTheme()
-    ->getName();
-  $variables['theme']['settings'] = \Drupal::config($theme . '.settings')->get();
-}
-
-/**
  * Prepares variables for the html template. Adds node object.
  *
  * Default template: html.html.twig.
@@ -63,7 +53,7 @@ function dxpr_theme_preprocess_html(&$variables) {
   if (!$bootstrap_cdn) {
     $variables['#attached']['library'][] = 'dxpr_theme/bootstrap3';
   }
-  
+
   if ($node = \Drupal::routeMatch()->getParameter('node')) {
     $variables['node'] = $node;
   }


### PR DESCRIPTION
## Linked issues

- fixes #217 

## Solution

restore theme settings by removing code that was intended for 2.x branch

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [ ] My code follows the coding standards and style of this project.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
