### PR TITLE
Added bootstrap5 as base theme for dxpr theme

### DIFF
--- a/dxpr_theme.info.yml
+++ b/dxpr_theme.info.yml
@@ -1,6 +1,6 @@
 type: theme
 core_version_requirement: ^8 || ^9 || ^10
-base theme: bootstrap4
+base theme: bootstrap5
 
 name: 'DXPR Theme'
 description: 'Low code framework theme by DXPR.'


### PR DESCRIPTION
## Linked issues

- #220 

## Solution

Added bootstrap5 as base theme for dxpr theme

@jjroelofs please download bootstrap5 from https://www.drupal.org/project/bootstrap5 and place it inside themes/contrib folder in your dxpr lighting repository.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My code follows the coding standards and style of this project.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
