### PR TITLE
Neslee/5.x/#238 fix status message close button

### DIFF
--- a/templates/status-messages.html.twig
+++ b/templates/status-messages.html.twig
@@ -55,7 +55,7 @@
   %}
   {# Reset the attribute classes and then add the message specific classes. #}
   <div{{ attributes.setAttribute('class', classes).addClass(message_classes).setAttribute('role', 'alert') }}>
-    <button role="button" class="close" data-dismiss="alert" aria-label="{{ 'Close'|t }}"><span aria-hidden="true">&times;</span></button>
+    <button type="button" role="button" class="btn-close" data-bs-dismiss="alert" aria-label="{{ 'Close'|t }}"></button>
     {% if status_headings[type] %}
       <h4 class="sr-only">{{ status_headings[type] }}</h4>
     {% endif %}


### PR DESCRIPTION
## Linked issues

- #238 

## Solution

Fixed the status message close button by fixing the html for close button

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My code follows the coding standards and style of this project.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
