### PR TITLE
Fixed drupal 10 depreactions for dxpr_theme

### DIFF
--- a/dxpr_theme.theme
+++ b/dxpr_theme.theme
@@ -83,7 +83,7 @@ function dxpr_theme_preprocess_html(&$variables) {
   }
 
   // Load Sooper Features Controllers.
-  foreach (\Drupal::service('file_system')->scanDirectory(drupal_get_path('theme', 'dxpr_theme') . '/features', '/controller.inc/i') as $file) {
+  foreach (\Drupal::service('file_system')->scanDirectory(\Drupal::service('extension.list.theme')->getPath('dxpr_theme') . '/features', '/controller.inc/i') as $file) {
     require_once $file->uri;
     $function_name = basename($file->filename, '.inc');
     $function_name = str_replace('-', '_', $function_name);

--- a/dxpr_theme_callbacks.inc
+++ b/dxpr_theme_callbacks.inc
@@ -30,7 +30,7 @@ function _dxpr_theme_css_cache_file($theme) {
 function dxpr_theme_color_module_css_write($theme) {
   // Stuff copied from color module, because this code is not encapsulated
   // in a function other than theme submit.
-  module_load_include('module', 'color');
+  \Drupal::moduleHandler()->loadInclude('module', 'color');
   $info = color_get_info($theme);
   $palette = color_get_palette($theme);
   $config = \Drupal::configFactory()->getEditable('color.theme.' . $theme);
@@ -62,7 +62,7 @@ function dxpr_theme_color_module_css_write($theme) {
   }
   $paths['target'] = $paths['target'] . '/';
   $paths['id'] = $id;
-  $paths['source'] = drupal_get_path('theme', $theme) . '/';
+  $paths['source'] = \Drupal::service('extension.list.theme')->getPath($theme) . '/';
   $paths['files'] = $paths['map'] = [];
 
   // Save palette and logo location.
@@ -96,7 +96,7 @@ function dxpr_theme_color_module_css_write($theme) {
     }
 
     foreach ($files as $file) {
-      $css_optimizer = new CssOptimizer();
+      $css_optimizer = new CssOptimizer($file);
       // Aggregate @imports recursively for each configured top level CSS file
       // without optimization. Aggregation and optimization will be
       // handled by drupal_build_css_cache() only.
@@ -152,7 +152,7 @@ function dxpr_theme_css_cache_build($theme) {
   // Construct CSS file:
   $css = '';
   // Load Sooper Features CSS.
-  foreach (\Drupal::service('file_system')->scanDirectory(drupal_get_path('theme', 'dxpr_theme') . '/features', '/css.inc/i') as $file) {
+  foreach (\Drupal::service('file_system')->scanDirectory(\Drupal::service('extension.list.theme')->getPath('dxpr_theme') . '/features', '/css.inc/i') as $file) {
     require_once $file->uri;
     $function_name = basename($file->filename, '.inc');
     $function_name = str_replace('-', '_', $function_name);
@@ -160,8 +160,8 @@ function dxpr_theme_css_cache_build($theme) {
       $function_name($theme, $css, $palette);
     }
   }
-  $file_object = file_save_data($css, $dxpr_theme_css_file, FileSystemInterface::EXISTS_REPLACE);
-  if ($dir_writable && !empty($file_object)) {
+  $file_object = \Drupal::service('file.repository')->writeData($css, $dxpr_theme_css_file, FileSystemInterface::EXISTS_REPLACE);
+  if ($dir_writable && $file_object) {
     $message = t('DXPR Theme CSS file cache built for %theme', ['%theme' => $theme]);
     \Drupal::messenger()->addMessage($message);
     \Drupal::logger('dxpr_theme')->notice($message);

--- a/features/sooper-fonts/fonts-theme-settings-controller.inc
+++ b/features/sooper-fonts/fonts-theme-settings-controller.inc
@@ -75,7 +75,7 @@ function _dxpr_theme_add_local_font($font, array &$variables) {
   $added_stylesheets = $added_stylesheets ?? [];
 
   $font = explode('|', substr($font, 1));
-  $path = drupal_get_path('theme', $font[0]) . $font[1];
+  $path = \Drupal::service('extension.list.theme')->getPath($font[0]) . $font[1];
   if (empty($added_stylesheets[$path])) {
     $element = [
       '#tag' => 'link',

--- a/features/sooper-fonts/fonts-theme-settings.inc
+++ b/features/sooper-fonts/fonts-theme-settings.inc
@@ -127,7 +127,7 @@ function dxpr_theme_local_webfonts() {
 
   $fonts = [];
   foreach ($theme_chain as $theme) {
-    $theme_path = drupal_get_path('theme', $theme);
+    $theme_path = \Drupal::service('extension.list.theme')->getPath($theme);
     if (!is_dir($theme_path . '/fonts')) {
       continue;
     }
@@ -216,7 +216,7 @@ function _dxpr_theme_font_previews() {
   $output .= '  <p>Check out <a href="http://www.google.com/webfonts">google.com/webfonts</a> for previews of google web fonts.</p>';
   $output .= '  <h3>Local fonts preview</h3>';
   $output .= '  <p>DXPR Theme will automatically detect and load any Fontsquirrel-generated @font-face package in the exmapletheme/fonts folder. See <a href="https://www.fontsquirrel.com/tools/webfont-generator">Fontsquirrel.com</a></p>';
-  foreach (dxpr_theme_local_webfonts(TRUE) as $key => $font_name) {
+  foreach (dxpr_theme_local_webfonts() as $key => $font_name) {
     $font = explode('|', $key);
     $local_name = $font[2];
     $output .= '  <div class="font-preview font-local" style="font-family:' . $local_name . '">';

--- a/features/sooper-layout/layout-theme-settings-css.inc
+++ b/features/sooper-layout/layout-theme-settings-css.inc
@@ -118,6 +118,6 @@ EOT;
   }
 
   if ($background_image_path = theme_get_setting('background_image_path', $theme)) {
-    $css .= "body { background-image: url('" . file_url_transform_relative(file_create_url($background_image_path)) . "'); }\n\n";
+    $css .= "body { background-image: url('" . \Drupal::service('file_url_generator')->generateString($background_image_path) . "'); }\n\n";
   }
 }

--- a/features/sooper-page-title/page_title-theme-settings-css.inc
+++ b/features/sooper-page-title/page_title-theme-settings-css.inc
@@ -89,6 +89,6 @@ EOT;
   }
 
   if ($page_title_image_path = theme_get_setting('page_title_image_path', $theme)) {
-    $css .= ".page-title-full-width-container:after { background-image: url('" . file_url_transform_relative(file_create_url($page_title_image_path)) . "'); }\n\n";
+    $css .= ".page-title-full-width-container:after { background-image: url('" . \Drupal::service('file_url_generator')->generateString($page_title_image_path) . "'); }\n\n";
   }
 }

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -25,7 +25,7 @@ function dxpr_theme_form_system_theme_settings_alter(&$form, &$form_state, $form
   };
   $build_info = $form_state->getBuildInfo();
   $subject_theme = $build_info['args'][0];
-  $dxpr_theme_theme_path = drupal_get_path('theme', 'dxpr_theme') . '/';
+  $dxpr_theme_theme_path = \Drupal::service('extension.list.theme')->getPath('dxpr_theme') . '/';
   $themes = \Drupal::service('theme_handler')->listInfo();
 
   $img = '<img style="width:35px;margin-right:5px;" src="' . $base_path . $dxpr_theme_theme_path . 'dxpr-logo-white.svg" />';
@@ -56,14 +56,14 @@ function dxpr_theme_form_system_theme_settings_alter(&$form, &$form_state, $form
    * settings are saved and once after the redirect with the updated settings.
    * @todo come up with a less 'icky' solution
    */
-  require_once drupal_get_path('theme', 'dxpr_theme') . '/dxpr_theme_callbacks.inc';
+  require_once \Drupal::service('extension.list.theme')->getPath('dxpr_theme') . '/dxpr_theme_callbacks.inc';
 
   $dxpr_theme_css_file = _dxpr_theme_css_cache_file($subject_theme);
   if (!file_exists($dxpr_theme_css_file)) {
     dxpr_theme_css_cache_build($subject_theme);
   }
 
-  foreach (\Drupal::service('file_system')->scanDirectory(drupal_get_path('theme', 'dxpr_theme') . '/features', '/settings.inc/i') as $file) {
+  foreach (\Drupal::service('file_system')->scanDirectory(\Drupal::service('extension.list.theme')->getPath('dxpr_theme') . '/features', '/settings.inc/i') as $file) {
     require_once $file->uri;
     $function_name = basename($file->filename, '.inc');
     $function_name = str_replace('-', '_', $function_name);
@@ -229,7 +229,7 @@ function _dxpr_theme_get_color_names($theme = NULL) {
     return $theme_info[$theme];
   }
 
-  $path = drupal_get_path('theme', $theme);
+  $path = \Drupal::service('extension.list.theme')->getPath($theme);
   $file = DRUPAL_ROOT . '/' . $path . '/color/color.inc';
   if ($path && file_exists($file)) {
     include $file;
@@ -359,7 +359,7 @@ function _dxpr_theme_validate_path($path) {
  * @see \Drupal\system\Form\ThemeSettingsForm::submitForm()
  */
 function dxpr_theme_form_system_theme_settings_after_submit(&$form, &$form_state) {
-  require_once drupal_get_path('theme', 'dxpr_theme') . '/dxpr_theme_callbacks.inc';
+  require_once \Drupal::service('extension.list.theme')->getPath('dxpr_theme') . '/dxpr_theme_callbacks.inc';
 
   $build_info = $form_state->getBuildInfo();
   $subject_theme = $build_info['args'][0];


### PR DESCRIPTION
## Linked issues

- #207 

## Solution

Fixed drupal 10 depreactions in theme

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [ ] My code follows the coding standards and style of this project.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
