### PR TITLE
[5.x] Added dependency on dxpr_theme_helper and color modules in info.yml

### DIFF
--- a/dxpr_theme.info.yml
+++ b/dxpr_theme.info.yml
@@ -6,6 +6,10 @@ name: 'DXPR Theme'
 description: 'Low code framework theme by DXPR.'
 package: DXPR
 
+dependencies:
+  - dxpr_theme_helper:dxpr_theme_helper
+  - drupal:color
+
 regions:
   secondary_header: 'Secondary Header'
   navigation: 'Navigation'


### PR DESCRIPTION
## Linked issues

- #281 

## Solution

Added dependency on dxpr_theme_helper and color modules in info.yml

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My code follows the coding standards and style of this project.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
