### PR TITLE
[5.x] Added headings bold settings for dxpr theme and sub theme

### DIFF
--- a/config/install/dxpr_theme.settings.yml
+++ b/config/install/dxpr_theme.settings.yml
@@ -52,6 +52,7 @@ blockquote_font_size: '21'
 blockquote_line_height: '1.5'
 headings_letter_spacing: '0'
 headings_uppercase: 0
+headings_bold: 0
 body_mobile_font_size: '14'
 nav_mobile_font_size: '14'
 h1_mobile_font_size: '52'

--- a/dxpr_theme_STARTERKIT/config/install/dxpr_theme_STARTERKIT.settings.yml
+++ b/dxpr_theme_STARTERKIT/config/install/dxpr_theme_STARTERKIT.settings.yml
@@ -52,6 +52,7 @@ blockquote_font_size: '21'
 blockquote_line_height: '1.5'
 headings_letter_spacing: '0'
 headings_uppercase: 0
+headings_bold: 0
 body_mobile_font_size: '14'
 nav_mobile_font_size: '14'
 h1_mobile_font_size: '52'

--- a/features/sooper-typography/typography-theme-settings-css.inc
+++ b/features/sooper-typography/typography-theme-settings-css.inc
@@ -34,6 +34,9 @@ function typography_theme_settings_css($theme, &$css, array $palette) {
   if (theme_get_setting('headings_uppercase', $theme)) {
     $css .= "h1,h2,h3,h4,h5,h6 { text-transform: uppercase; } \n";
   }
+  if (theme_get_setting('headings_bold', $theme)) {
+    $css .= "h1,h2,h3,h4,h5,h6 { font-weight: bold; } \n";
+  }
   if ($height = theme_get_setting('divider_thickness', $theme)) {
     $css .= "hr { border-top-width:  " . $height . "px; } \n";
   }

--- a/features/sooper-typography/typography-theme-settings.inc
+++ b/features/sooper-typography/typography-theme-settings.inc
@@ -141,6 +141,14 @@ function typography_theme_settings(array &$form, $theme) {
     '#maxlength' => 9,
   ];
 
+  $form['dxpr_theme_settings']['typography']['advanced_type']['headings_bold'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Headings Bold'),
+    '#default_value' => ((theme_get_setting('headings_bold') !== NULL)) ? theme_get_setting('headings_bold') : FALSE,
+    '#size' => 9,
+    '#maxlength' => 9,
+  ];
+
   $form['dxpr_theme_settings']['typography']['advanced_type']['mobile_type'] = [
     '#title' => t('Mobile Type Controls'),
     '#type' => 'details',


### PR DESCRIPTION
## Linked issues

- #296 

## Solution

Created new settings called Headings bold under typography which will add bold styling for all headings tags.


## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My code follows the coding standards and style of this project.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
