### PR TITLE
[5.x] Fixed drupal is not defined console error

### DIFF
--- a/dxpr_theme.libraries.yml
+++ b/dxpr_theme.libraries.yml
@@ -4,6 +4,7 @@ global-styling:
     js/minified/dxpr-theme-multilevel-mobile-nav.min.js: { minified: true }
     js/minified/dxpr-theme-header.min.js: { minified: true }
   dependencies:
+    - core/drupal
     - core/jquery
     - core/once
     - core/modernizr
@@ -100,6 +101,7 @@ drupal-breadcrumbs:
     theme:
       css/vendor-extensions/drupal-breadcrumbs.css: { minified: true }
   dependencies:
+    - core/drupal
     - core/once
 
 drupal-comments:
@@ -194,6 +196,7 @@ admin.themesettings:
       vendor/bootstrap-slider/bootstrap-slider.min.css: {}
       css/dxpr-theme.admin.themesettings.css: {}
   dependencies:
+    - core/drupal
     - core/jquery
     - core/once
 


### PR DESCRIPTION
## Linked issues

- #300 

## Solution

In drupal 10, fixed drupal is not defined console error by adding core/drupal as a dependency in libraries.yml file

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My code follows the coding standards and style of this project.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
