### PR TITLE
Fixed #327: Added function to load fonts for the preview

### DIFF
--- a/features/sooper-fonts/fonts-theme-settings.inc
+++ b/features/sooper-fonts/fonts-theme-settings.inc
@@ -5,6 +5,8 @@
  * Theme fonts settings.
  */
 
+use Drupal\Core\Render\Markup;
+
 /**
  * Add font options to the theme settings form.
  *
@@ -113,6 +115,11 @@ function fonts_theme_settings(array &$form, $theme) {
     '#type' => 'markup',
     '#markup' => _dxpr_theme_font_previews(),
   ];
+
+  // Load local fonts to use in preview.
+  foreach (dxpr_theme_local_webfonts() as $key => $font_name) {
+    _dxpr_theme_add_preview_font($key, $form);
+  }
 }
 
 /**
@@ -226,5 +233,36 @@ function _dxpr_theme_font_previews() {
     $output .= '  </div>';
   }
   $output .= '</div>';
-  return $output;
+  return Markup::create($output);
+}
+
+/**
+ * Loads font to use in preview form.
+ *
+ * @param string $font
+ *   Requested font.
+ * @param array $form
+ *   An associative array containing the structure of the form.
+ */
+function _dxpr_theme_add_preview_font($font, array &$form) {
+  global $base_url;
+
+  $added_stylesheets = &drupal_static(__FUNCTION__);
+  $added_stylesheets = $added_stylesheets ?? [];
+
+  $font = explode('|', substr($font, 1));
+  $path = \Drupal::service('extension.list.theme')
+      ->getPath($font[0]) . $font[1];
+  if (empty($added_stylesheets[$path])) {
+    $element = [
+      '#tag' => 'link',
+      '#attributes' => [
+        'href' => $base_url . '/' . $path,
+        'rel' => 'stylesheet',
+        'type' => 'text/css',
+      ],
+    ];
+    $form['#attached']['html_head'][] = [$element, $font[2]];
+    $added_stylesheets[$path] = $path;
+  }
 }


### PR DESCRIPTION
## Linked issues

- #327 

## Solution

<img width="672" alt="Screenshot 2023-01-23 at 16 39 36" src="https://user-images.githubusercontent.com/29509266/214067070-b79441c9-33d1-4cce-8848-850b99ce3cc9.png">

<img width="1351" alt="Screenshot 2023-01-23 at 16 37 42" src="https://user-images.githubusercontent.com/29509266/214066989-b459f08a-cc03-41e3-9354-39a74ce21ca0.png">


## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
