### PR TITLE
Fixed #341: Updated styling for comments

### DIFF
--- a/dxpr_theme.theme
+++ b/dxpr_theme.theme
@@ -302,6 +302,7 @@ function dxpr_theme_preprocess_breadcrumb(&$variables) {
  */
 function dxpr_theme_preprocess_comment(&$variables) {
   if ($variables['elements']['#comment']) {
+    $variables['#attached']['library'][] = 'bootstrap5/indented';
     $variables['#attached']['library'][] = 'dxpr_theme/drupal-comments';
   }
 }


### PR DESCRIPTION
## Linked issues

- #341 

## Solution

Used styling from Olivero, haven't added JS to show/hide thread to keep it simple.

How it looks like on Olivero:
<img width="1311" alt="Screenshot 2023-02-26 at 21 58 27" src="https://user-images.githubusercontent.com/29509266/221434288-9c039ee4-8bf5-4a41-b440-e98361cc144d.png">

How it looks like on DXPR Theme:
<img width="1370" alt="Screenshot 2023-02-26 at 21 58 17" src="https://user-images.githubusercontent.com/29509266/221434296-ca7a09d9-71d9-4c56-97f8-b0197ac6ec76.png">

How it looks like on DXPR Theme with user picture:
<img width="1394" alt="Screenshot 2023-02-26 at 21 57 41" src="https://user-images.githubusercontent.com/29509266/221434306-b96fe4cd-552b-4767-999e-a4211047d1ba.png">
<img width="523" alt="Screenshot 2023-02-26 at 21 57 52" src="https://user-images.githubusercontent.com/29509266/221434314-d9b0c7f1-24c0-46f5-b583-b85081984ae9.png">


## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My code follows the coding standards and style of this project.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
