### PR TITLE
split breadcrumbs and full screen search libraries in separate js and…

### DIFF
--- a/dxpr_theme.libraries.yml
+++ b/dxpr_theme.libraries.yml
@@ -50,14 +50,16 @@ typography:
       css/base/typography.css: { minified: true }
 
 dxpr-theme-full-screen-search:
+  css:
+    theme:
+      css/components/dxpr-theme-full-screen-search.css: { minified: true }
+
+dxpr-theme-full-screen-search-js:
   js:
     js/minified/dxpr-theme-full-screen-search.min.js: { minified: true }
   dependencies:
     - core/jquery
     - core/once
-  css:
-    theme:
-      css/components/dxpr-theme-full-screen-search.css: { minified: true }
 
 dxpr-theme-header:
   css:
@@ -100,13 +102,15 @@ cubeportfolio:
       css/vendor-extensions/cubeportfolio.css: { minified: true }
 
 drupal-breadcrumbs:
-  js:
-    js/minified/dxpr-theme-breadcrumbs.min.js: { minified: true }
   css:
     theme:
       css/vendor-extensions/drupal-breadcrumbs.css: { minified: true }
   dependencies:
     - core/drupal
+
+drupal-breadcrumbs-js:
+  js:
+    js/minified/dxpr-theme-breadcrumbs.min.js: { minified: true }
 
 drupal-comments:
   css:

--- a/dxpr_theme.theme
+++ b/dxpr_theme.theme
@@ -235,6 +235,7 @@ function dxpr_theme_preprocess_block(&$variables) {
   // Include DXPR Theme full search block css library.
   if ($variables['plugin_id'] === 'full_screen_search') {
     $variables['#attached']['library'][] = 'dxpr_theme/dxpr-theme-full-screen-search';
+    $variables['#attached']['library'][] = 'dxpr_theme/dxpr-theme-full-screen-search-js';
   }
 }
 
@@ -271,6 +272,7 @@ function dxpr_theme_preprocess_region(&$variables) {
 function dxpr_theme_preprocess_breadcrumb(&$variables) {
   if ($variables['breadcrumb']) {
     $variables['#attached']['library'][] = 'dxpr_theme/drupal-breadcrumbs';
+    $variables['#attached']['library'][] = 'dxpr_theme/drupal-breadcrumbs-js';
   }
 }
 


### PR DESCRIPTION
… css libraries so that the subtheme overriding the base theme css libraries does not prevent the js files from loading

## Linked issues

- #366 

## Solution

BRIEFLY_DESCRIBE_YOUR_PULL_REQUEST_HERE

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [ ] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [ ] My code follows the coding standards and style of this project.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
