### PR TITLE
get realpath instead of external URI

### DIFF
--- a/features/sooper-fonts/fonts-theme-settings-controller.inc
+++ b/features/sooper-fonts/fonts-theme-settings-controller.inc
@@ -76,18 +76,24 @@ function _dxpr_theme_add_google_fonts(array $google_fonts, array &$variables) {
   }
 
   if ($wrapper = \Drupal::service('stream_wrapper_manager')->getViaUri($fonts_folder_uri . '/' . 'font-face.css')) {
-    $absolute_file_source = $wrapper->getExternalUrl();
+    $local_path = $wrapper->realpath();
 
-    $element = [
-      '#tag' => 'style',
-      '#value' => str_replace(["\r", "\n"], '', file_get_contents($absolute_file_source)),
-    ];
+    if (!empty($local_path)) {
+      $file_content = file_get_contents($local_path);
+      $file_content = str_replace(["\r", "\n"], '', $file_content);
 
-    $variables['#attached']['html_head'][] = [
-      $element,
-      'dxpr_theme_google_fonts',
-    ];
+      $element = [
+        '#tag' => 'style',
+        '#value' => $file_content,
+      ];
+
+      $variables['#attached']['html_head'][] = [
+        $element,
+        'dxpr_theme_google_fonts',
+      ];
+    }
   }
+
 }
 
 /**
@@ -263,16 +269,19 @@ function _dxpr_theme_add_local_font_parse_font_families($path) {
   $font_families = $font_families ?? [];
   if (!isset($font_families[$path])) {
     $font_families[$path] = [];
-    $content = file_get_contents($path);
-    preg_match_all('/@font-face\s*{([\s\S]*?)}/i', $content, $font_faces);
-    foreach ($font_faces[1] as $font_face) {
-      if (preg_match('/font-family: [\'"](.*?)[\'"]/i', $font_face, $font_family)) {
-        $font_families[$path][$font_family[1]] = [];
-        if (preg_match('/src[\s]*:[\s]*url\([\'"]*(.+?)[\'"]*\)[\s]*format\([\'"]*(.+?)[\'"]*\)/i', $font_face, $matches)) {
-          $font_families[$path][$font_family[1]] = [
-            'url' => $matches[1],
-            'format' => $matches[2],
-          ];
+    if ($wrapper = \Drupal::service('stream_wrapper_manager')->getViaUri($path)) {
+      $local_path = $wrapper->realpath();
+      $content = file_get_contents($local_path);
+      preg_match_all('/@font-face\s*{([\s\S]*?)}/i', $content, $font_faces);
+      foreach ($font_faces[1] as $font_face) {
+        if (preg_match('/font-family: [\'"](.*?)[\'"]/i', $font_face, $font_family)) {
+          $font_families[$path][$font_family[1]] = [];
+          if (preg_match('/src[\s]*:[\s]*url\([\'"]*(.+?)[\'"]*\)[\s]*format\([\'"]*(.+?)[\'"]*\)/i', $font_face, $matches)) {
+            $font_families[$path][$font_family[1]] = [
+              'url' => $matches[1],
+              'format' => $matches[2],
+            ];
+          }
         }
       }
     }


### PR DESCRIPTION
## Linked issues

- #404 

## Solution

We don't need to get it from external URL because we have these files on local file system, also the external fetching was causing SSL problems on try.dxpr.com.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
