### PR TITLE
Fixed #404: Load font files from local

### DIFF
--- a/features/sooper-fonts/fonts-theme-settings-controller.inc
+++ b/features/sooper-fonts/fonts-theme-settings-controller.inc
@@ -167,9 +167,9 @@ function _dxpr_theme_cache_google_fonts(array $google_fonts, string $fonts_folde
 
     // Update font-face to use local links.
     if ($wrapper = \Drupal::service('stream_wrapper_manager')->getViaUri($file_name)) {
-      $absolute_file_source = \Drupal::service('file_url_generator')
+      $relative_file_source = \Drupal::service('file_url_generator')
         ->transformRelative($wrapper->getExternalUrl());
-      $font_face = str_replace($font_source, $absolute_file_source, $font_face);
+      $font_face = str_replace($font_source, $relative_file_source, $font_face);
     }
   }
 


### PR DESCRIPTION
## Linked issues

- #404 

## Solution

Load font file from local without http/https in the url.
<img width="2048" alt="Screenshot 2023-04-10 at 17 35 57" src="https://user-images.githubusercontent.com/29509266/230922836-e0b7a6fe-cd82-4fe0-b270-be58741e2111.png">


## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
