### PR TITLE
Fixed #323: Removed type hinting for D7 instllations

### DIFF
--- a/features/sooper-fonts/fonts-theme-settings-controller.inc
+++ b/features/sooper-fonts/fonts-theme-settings-controller.inc
@@ -31,10 +31,10 @@ if (!empty($requested_google_fonts)) {
 /**
  * Helper function to add google fonts to the page.
  *
- * @param array $google_fonts
+ * @param $google_fonts
  *   Requested Google fonts.
  */
-function _dxpr_theme_add_google_fonts(array $google_fonts) {
+function _dxpr_theme_add_google_fonts($google_fonts) {
   $planned_fonts_update = variable_get('dxpr_theme_fonts_update', 0);
   $stored_fonts = variable_get('dxpr_theme_stored_fonts', '');
 

--- a/includes/dxpr_theme_menu_link.inc
+++ b/includes/dxpr_theme_menu_link.inc
@@ -7,7 +7,7 @@
 /**
  * Override menu link to support multilevel dropdowns.
  *
- * @param array $variables
+ * @param $variables
  *   An associative array containing:
  *   - element: Structured array data for a menu link.
  *
@@ -18,7 +18,7 @@
  *
  * @ingroup theme_functions
  */
-function dxpr_theme_menu_link(array $variables) {
+function dxpr_theme_menu_link($variables) {
   global $theme;
   // Global $theme_path variable is buggy so we create our own vars
   // @see https://github.com/dxpr/dxpr_theme/issues/170


### PR DESCRIPTION
## Linked issues

- #323 
- https://www.drupal.org/project/dxpr_theme/issues/3379566

## Solution

Issue might be caused by PHP type hinting. Asked user for more info.
Tested my solution locally on Drupal 7 - works as expected. Once I get his PHP version - will do more tests.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [ ] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [ ] My code follows the coding standards and style of this project.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
