### PR TITLE
#466 - Call to undefined function on install

### DIFF
--- a/dxpr_theme_callbacks.inc
+++ b/dxpr_theme_callbacks.inc
@@ -5,6 +5,7 @@
  * DXPR Theme helper functions.
  */
 
+use Drupal\Component\Serialization\Json;
 use Drupal\Core\File\FileSystemInterface;
 
 /**
@@ -49,7 +50,23 @@ function dxpr_theme_css_cache_build(string $theme) {
 
   $palette = unserialize((theme_get_setting('color_palette', $theme) ?? ''), [
     'allowed_classes' => FALSE,
-  ]) ?: _dxpr_theme_get_color_scheme();
+  ]) ?: NULL;
+
+  // Fetch default palette.
+  if (empty($palette)) {
+    $path = \Drupal::service('extension.list.theme')->getPath('dxpr_theme');
+    $filepath = sprintf('%s/%s/features/sooper-colors/color-settings.json', DRUPAL_ROOT, $path);
+
+    if ($path && file_exists($filepath)) {
+      $json = file_get_contents($filepath);
+      $settings = Json::decode($json);
+      $palette = $settings['schemes']['default']['colors'] ?? [];
+    }
+
+    if (empty($palette)) {
+      \Drupal::messenger()->addWarning(t('Could not create theme styles; please resave theme settings.'));
+    }
+  }
 
   // Construct CSS file:
   $css = '';


### PR DESCRIPTION
## Linked issues

- #466

## Solution

Remove call to `_dxpr_theme_get_color_scheme()` during install, and instead fetch default color scheme directly.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
