### PR TITLE
#482 Core search block not affected by "Block card style" theme setting

### DIFF
--- a/templates/block--search-form-block.html.twig
+++ b/templates/block--search-form-block.html.twig
@@ -26,10 +26,17 @@
  * @see search_preprocess_block()
  */
 #}
+{% set designRegions = [] %}
+{% for name in theme.settings.block_design_regions %}
+  {% if name %}
+    {% set designRegions = designRegions|merge([name]) %}
+  {% endif %}
+{% endfor %}
 {%
     set classes = [
     'block',
     'block-search',
+    theme.settings.block_card and region in designRegions ? theme.settings.block_card,
 ]
 %}
 <div{{ attributes.addClass(classes) }}>


### PR DESCRIPTION
The Search form block is not being styled by the custom theme settings under "Block card style." It appears that a template override for this block might be preventing the custom styles from being applied.

## Linked issues

- #482 

## Solution

Add CSS classes necessary for styling the core Search block as per the theme settings.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
