### PR TITLE
#411: Fix issue with regions with only html content not being rendered

### DIFF
--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -57,6 +57,12 @@
  * @see html.html.twig
  */
 #}
+{%- macro hasContent(region) -%}
+  {%- set keep_tags = '<drupal-render-placeholder><form><embed><hr><iframe><img><input><link><object><script><source><style><video>' -%}
+  {%- set content = region|render|replace({"\n": "", "\r": "", "\t": ""})|striptags(keep_tags)|trim -%}
+  {{- content ? 'TRUE' -}}
+{%- endmacro -%}
+
 {% if not node.field_dth_page_layout.getString() and theme.settings.boxed_layout
   or node.field_dth_page_layout.getString() == 'boxed' %}
 <div class="dxpr-theme-boxed-container">
@@ -185,17 +191,20 @@
 
 {# Main #}
 {% block main %}
+  {% set has_sidebar_first  = _self.hasContent(page.sidebar_first) %}
+  {% set has_sidebar_second = _self.hasContent(page.sidebar_second) %}
   {% set container = theme.settings.full_width_containers.cnt_content
   or node.field_dth_main_content_width.getString() == 'dxpr-theme-util-full-width-content'
   or node and attribute(theme.settings.full_width_content_types, node.getType)
-  and not page.sidebar_first|render|striptags|trim
-  and not page.sidebar_second|render|striptags|trim ? '' : 'container' %}
+  and not has_sidebar_first
+  and not has_sidebar_second ? '' : 'container' %}
+
   <div role="main" class="main-container {{ container }} js-quickedit-main-content clearfix">
     {% if container != '' %}
     <div class="row">
     {% endif %}
       {# Sidebar First #}
-      {% if page.sidebar_first|render|striptags|trim %}
+      {% if has_sidebar_first %}
         {% block sidebar_first %}
           <aside class="col-sm-3" role="complementary">
             {{ page.sidebar_first }}
@@ -207,10 +216,10 @@
       {% if not node.field_dth_main_content_width.getString() %}
         {%
           set content_classes = [
-            page.sidebar_first|render|striptags|trim and page.sidebar_second|render|striptags|trim ? 'col-sm-6',
-            page.sidebar_first|render|striptags|trim and page.sidebar_second|render|striptags|trim is empty ? 'col-sm-9',
-            page.sidebar_second|render|striptags|trim and page.sidebar_first|render|striptags|trim is empty ? 'col-sm-9',
-            container != '' and page.sidebar_first|render|striptags|trim is empty and page.sidebar_second|render|striptags|trim is empty ? 'col-sm-12'
+            has_sidebar_first and has_sidebar_second ? 'col-sm-6',
+            has_sidebar_first and not has_sidebar_second ? 'col-sm-9',
+            has_sidebar_second and not has_sidebar_first ? 'col-sm-9',
+            container != '' and not has_sidebar_first and not has_sidebar_second ? 'col-sm-12'
           ]
         %}
       {% else %}
@@ -249,7 +258,7 @@
       </section>
 
       {# Sidebar Second #}
-      {% if page.sidebar_second|render|striptags|trim %}
+      {% if has_sidebar_second %}
         {% block sidebar_second %}
           <aside class="col-sm-3" role="complementary">
             {{ page.sidebar_second }}


### PR DESCRIPTION
Regions with only html content such as `<img>` or `<form>` tags were not displayed due to all html being stripped away. 

## Linked issues

- #411 

## Solution

This commit fixes the issue by using a macro to check if the region is empty. In addition two new `has_content_*` variables are used in the logic checks to prevent multiple renders of the sidebars.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
