### PR TITLE
Fix drupal-lint error in post_update hook

### DIFF
--- a/dxpr_theme.post_update.php
+++ b/dxpr_theme.post_update.php
@@ -24,7 +24,7 @@ function dxpr_theme_post_update_n1_migrate_colors() {
   /** @var \Drupal\Core\Extension\Extension $theme */
   foreach ($theme_list as $theme) {
     $theme_name = $theme->getName();
-    if ('dxpr_theme' === ($theme->info['base theme'] ?? '') OR 'dxpr_theme' === $theme_name) {
+    if ('dxpr_theme' === ($theme->info['base theme'] ?? '') || 'dxpr_theme' === $theme_name) {
 
       $config = \Drupal::configFactory()
         ->getEditable($theme_name . '.settings');


### PR DESCRIPTION
This commit fixes a drupal-lint error:
> PHP keywords must be lowercase; expected "or" but found "OR".

modified: dxpr_theme.post_update.php

## Linked issues

N/A

## Solution

Replace "OR" with "||".

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
