### PR TITLE
Fix incorrect Bootstrap offset classes in page design settings

### DIFF
--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -226,10 +226,10 @@
         {% set col = node.field_dth_main_content_width.getString() %}
         {%
           set content_classes = [
-            col == 'dxpr-theme-util-content-center-4-col' ? 'col-md-4 col-md-offset-4',
-            col == 'dxpr-theme-util-content-center-6-col' ? 'col-md-6 col-md-offset-3',
-            col == 'dxpr-theme-util-content-center-8-col' ? 'col-md-8 col-md-offset-2',
-            col == 'dxpr-theme-util-content-center-10-col' ? 'col-md-10 col-md-offset-1',
+            col == 'dxpr-theme-util-content-center-4-col' ? 'col-md-4 offset-md-4',
+            col == 'dxpr-theme-util-content-center-6-col' ? 'col-md-6 offset-md-3',
+            col == 'dxpr-theme-util-content-center-8-col' ? 'col-md-8 offset-md-2',
+            col == 'dxpr-theme-util-content-center-10-col' ? 'col-md-10 offset-md-1',
           ]
         %}
       {% endif %}


### PR DESCRIPTION
Updated the Twig template for the "Main content width" setting in DXPR Page Design to use Bootstrap 5 offset classes instead of Bootstrap 3. This change ensures the masthead content is centered properly across all device sizes, fixing the issue where it was sticking to the left side of the viewport.

Replaced col-md-offset-x with the correct offset-md-x classes to align with Bootstrap 5 syntax.

## Linked issues

- #504 

## Solution

BRIEFLY_DESCRIBE_YOUR_PULL_REQUEST_HERE

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [ ] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [ ] My commit messages follow the contributing standards and style of this project.
- [ ] My code follows the coding standards and style of this project.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
