### PR TITLE
#546: Move several theme settings helper functions to dxpr_theme_callbacks.inc

### DIFF
--- a/dxpr_theme_callbacks.inc
+++ b/dxpr_theme_callbacks.inc
@@ -341,3 +341,82 @@ function _dxpr_theme_font_stack($font = 'helvetica') {
   }
   return $fonts[$font];
 }
+
+/**
+ * Returns data from the color-settings.json file.
+ *
+ * @param string|null $key
+ *   Key index in color.inc $info array.
+ *
+ * @return array
+ *   Array containing requested data.
+ */
+function _dxpr_theme_get_color_inc(?string $key = NULL): array {
+  $path = \Drupal::service('extension.list.theme')->getPath('dxpr_theme');
+  $filepath = sprintf('%s/%s/features/sooper-colors/color-settings.json', DRUPAL_ROOT, $path);
+
+  if ($path && file_exists($filepath)) {
+    $json = file_get_contents($filepath);
+    $settings = Json::decode($json);
+
+    if ($settings) {
+      $data = $key ? ($settings[$key] ?? []) : $settings;
+    }
+  }
+
+  return $data ?? [];
+}
+
+/**
+ * Returns the color field keys.
+ *
+ * @return array
+ *   The 'fields' sub-array.
+ */
+function _dxpr_theme_get_color_names(): array {
+  return _dxpr_theme_get_color_inc('fields');
+}
+
+/**
+ * Returns the color schemes.
+ *
+ * @return array
+ *   The 'schemes' sub-array.
+ */
+function _dxpr_theme_get_color_schemes(): array {
+  return _dxpr_theme_get_color_inc('schemes');
+}
+
+/**
+ * Returns the specified color scheme, defaults to 'default'.
+ *
+ * @param string $scheme
+ *   The color scheme machine name.
+ *
+ * @return array
+ *   The specified color scheme indexed by color machine names.
+ */
+function _dxpr_theme_get_color_scheme(string $scheme = 'default'): array {
+  $schemes = _dxpr_theme_get_color_schemes();
+  return $schemes['default'] ?? [];
+}
+
+/**
+ * Color options for theme settings.
+ *
+ * @param string $theme
+ *   Theme machine name.
+ *
+ * @return array
+ *   Color options.
+ */
+function _dxpr_theme_color_options($theme) {
+  $colors = [
+    '' => t('None (Theme Default)'),
+    'white' => t('White'),
+    'custom' => t('Custom Color'),
+  ];
+  $theme_colors = _dxpr_theme_get_color_names($theme);
+  $colors = array_merge($colors, $theme_colors);
+  return $colors;
+}

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -5,7 +5,6 @@
  * DXPR Theme settings.
  */
 
-use Drupal\Component\Serialization\Json;
 use Drupal\Core\File\Exception\FileException;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\node\Entity\NodeType;
@@ -288,85 +287,6 @@ function dxpr_theme_form_system_theme_settings_submit(&$form, &$form_state) {
   }
 
   $form_state->setValue('color_palette', serialize($color_palette));
-}
-
-/**
- * Returns data from the color-settings.json file.
- *
- * @param string|null $key
- *   Key index in color.inc $info array.
- *
- * @return array
- *   Array containing requested data.
- */
-function _dxpr_theme_get_color_inc(?string $key = NULL): array {
-  $path = \Drupal::service('extension.list.theme')->getPath('dxpr_theme');
-  $filepath = sprintf('%s/%s/features/sooper-colors/color-settings.json', DRUPAL_ROOT, $path);
-
-  if ($path && file_exists($filepath)) {
-    $json = file_get_contents($filepath);
-    $settings = Json::decode($json);
-
-    if ($settings) {
-      $data = $key ? ($settings[$key] ?? []) : $settings;
-    }
-  }
-
-  return $data ?? [];
-}
-
-/**
- * Returns the color field keys.
- *
- * @return array
- *   The 'fields' sub-array.
- */
-function _dxpr_theme_get_color_names(): array {
-  return _dxpr_theme_get_color_inc('fields');
-}
-
-/**
- * Returns the color schemes.
- *
- * @return array
- *   The 'schemes' sub-array.
- */
-function _dxpr_theme_get_color_schemes(): array {
-  return _dxpr_theme_get_color_inc('schemes');
-}
-
-/**
- * Returns the specified color scheme, defaults to 'default'.
- *
- * @param string $scheme
- *   The color scheme machine name.
- *
- * @return array
- *   The specified color scheme indexed by color machine names.
- */
-function _dxpr_theme_get_color_scheme(string $scheme = 'default'): array {
-  $schemes = _dxpr_theme_get_color_schemes();
-  return $schemes['default'] ?? [];
-}
-
-/**
- * Color options for theme settings.
- *
- * @param string $theme
- *   Theme machine name.
- *
- * @return array
- *   Color options.
- */
-function _dxpr_theme_color_options($theme) {
-  $colors = [
-    '' => t('None (Theme Default)'),
-    'white' => t('White'),
-    'custom' => t('Custom Color'),
-  ];
-  $theme_colors = _dxpr_theme_get_color_names($theme);
-  $colors = array_merge($colors, $theme_colors);
-  return $colors;
 }
 
 /**


### PR DESCRIPTION
This PR fixes an issue with running Drupal updates due to an undefined function PHP error. This is resolved by moving required functions from the `theme-settings.php` file to the `dxpr_theme_callbacks.inc` file.

## Linked issues

- #546

## Solution

Required functions moved to `dxpr_theme_callbacks.inc`.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
