### PR TITLE
Drale1/6.x/#555 menu dropdown text color issue

### DIFF
--- a/features/sooper-header/header-theme-settings-css.inc
+++ b/features/sooper-header/header-theme-settings-css.inc
@@ -222,4 +222,57 @@ function header_theme_settings_css(string $theme, string &$css, array $palette) 
     $css .= "}\n\n";
   }
 
+  // Handle dropdown text color.
+  $dropdown_text_color = theme_get_setting('dropdown_text_color');
+  $dropdown_custom_color = theme_get_setting('dropdown_text_color_custom');
+  $color_palette = unserialize(theme_get_setting('color_palette'));
+  $headertext = $color_palette['headertext'];
+
+//   dump($color_palette); headertext
+  // dump(theme_get_setting('color_palette'));
+
+  if ($dropdown_text_color === '') {
+    // Default to header text color if dropdown color is not set.
+    $css .= "
+    #block-dxpr-theme-main-menu .dropdown-menu {
+      .dropdown {
+        color: $headertext !important;
+
+        * {
+          color: $headertext !important;
+        }
+      }
+    }
+  ";
+  } else {
+    // Determine the dropdown text color.
+    if ($dropdown_text_color === 'custom') {
+      $color_value = $dropdown_custom_color; // Use the custom color.
+    }
+    else {
+      // Fetch the color from the palette if available.
+      $color_value = isset($color_palette[$dropdown_text_color])
+        ? $color_palette[$dropdown_text_color]
+        : "dxpr-color('$dropdown_text_color')"; // Fallback to dxpr-color if not in palette.
+    }
+
+//    SADA RJEŠI DA KADA SE ODABERE MENU TEXT DA SE KUPI TA BOJA NA MENU TEXT
+    // Generate the CSS for the dropdown text color.
+    $css .= "
+    #block-dxpr-theme-main-menu {
+     .dropdown-menu {
+        .dropdown {
+          color: $color_value !important;
+
+          * {
+            color: $color_value !important;
+          }
+        }
+      }
+      .expanded.dropdown a {
+        color: $headertext;
+      }
+    }
+  ";
+  }
 }

--- a/features/sooper-header/header-theme-settings-css.inc
+++ b/features/sooper-header/header-theme-settings-css.inc
@@ -222,17 +222,33 @@ function header_theme_settings_css(string $theme, string &$css, array $palette) 
     $css .= "}\n\n";
   }
 
-  // Handle dropdown text color.
+  // Handle dropdown text and menu text color.
   $dropdown_text_color = theme_get_setting('dropdown_text_color');
   $dropdown_custom_color = theme_get_setting('dropdown_text_color_custom');
-  $color_palette = unserialize(theme_get_setting('color_palette'));
+  $menu_text_color = theme_get_setting('menu_text_color');
+  $menu_text_color_custom = theme_get_setting('menu_text_color_custom');
+  $color_palette = unserialize(theme_get_setting('color_palette'), ['allowed_classes' => FALSE]);
   $headertext = $color_palette['headertext'];
 
-//   dump($color_palette); headertext
-  // dump(theme_get_setting('color_palette'));
+  /**
+   * This function returns the custom color if specified,
+   * otherwise it fetches the color from the palette.
+   */
+  function resolve_color($color, $custom_color, $color_palette) {
+    if ($color === 'custom') {
+      // Use the custom color.
+      return $custom_color;
+    }
+    // Fallback to default color format.
+    return $color_palette[$color] ?? "dxpr-color('$color')";
+  }
 
-  if ($dropdown_text_color === '') {
-    // Default to header text color if dropdown color is not set.
+  // Resolve dropdown and menu text colors using the helper function.
+  $dropdown_color_value = resolve_color($dropdown_text_color, $dropdown_custom_color, $color_palette);
+  $menu_color_value = resolve_color($menu_text_color, $menu_text_color_custom, $color_palette);
+
+  if ($dropdown_text_color === '' && $menu_text_color === '') {
+    // Handles the case where both dropdown and menu text colors are not set.
     $css .= "
     #block-dxpr-theme-main-menu .dropdown-menu {
       .dropdown {
@@ -244,33 +260,62 @@ function header_theme_settings_css(string $theme, string &$css, array $palette) 
       }
     }
   ";
-  } else {
-    // Determine the dropdown text color.
-    if ($dropdown_text_color === 'custom') {
-      $color_value = $dropdown_custom_color; // Use the custom color.
-    }
-    else {
-      // Fetch the color from the palette if available.
-      $color_value = isset($color_palette[$dropdown_text_color])
-        ? $color_palette[$dropdown_text_color]
-        : "dxpr-color('$dropdown_text_color')"; // Fallback to dxpr-color if not in palette.
-    }
-
-//    SADA RJEŠI DA KADA SE ODABERE MENU TEXT DA SE KUPI TA BOJA NA MENU TEXT
-    // Generate the CSS for the dropdown text color.
+  }
+  elseif ($dropdown_text_color === '' && $menu_text_color !== '') {
+    // Handles the case where the dropdown color
+    // is not set but the menu text color is set.
     $css .= "
     #block-dxpr-theme-main-menu {
      .dropdown-menu {
         .dropdown {
-          color: $color_value !important;
+          color: $headertext !important;
 
           * {
-            color: $color_value !important;
+            color: $headertext !important;
+          }
+        }
+      }
+    }
+    #navbar #block-dxpr-theme-main-menu  .expanded.dropdown a {
+      color: $menu_color_value;
+    }
+  ";
+  }
+  elseif ($dropdown_text_color !== '' && $menu_text_color === '') {
+    // Handles the case where the dropdown color
+    // is set but the menu text color is not.
+    $css .= "
+    #block-dxpr-theme-main-menu {
+     .dropdown-menu {
+        .dropdown {
+          color: $dropdown_color_value !important;
+
+          * {
+            color: $dropdown_color_value !important;
           }
         }
       }
       .expanded.dropdown a {
         color: $headertext;
+      }
+    }
+  ";
+  }
+  else {
+    // Handles the case where both dropdown and menu text colors are set.
+    $css .= "
+    #block-dxpr-theme-main-menu {
+     .dropdown-menu {
+        .dropdown {
+          color: $dropdown_color_value !important;
+
+          * {
+            color: $dropdown_color_value !important;
+          }
+        }
+      }
+      .expanded.dropdown a {
+        color: $menu_color_value;
       }
     }
   ";

--- a/features/sooper-header/header-theme-settings-css.inc
+++ b/features/sooper-header/header-theme-settings-css.inc
@@ -252,10 +252,10 @@ function header_theme_settings_css(string $theme, string &$css, array $palette) 
     $css .= "
     #block-dxpr-theme-main-menu .dropdown-menu {
       .dropdown {
-        color: $headertext !important;
+        color: $headertext;
 
         * {
-          color: $headertext !important;
+          color: $headertext;
         }
       }
     }
@@ -271,7 +271,7 @@ function header_theme_settings_css(string $theme, string &$css, array $palette) 
           color: $headertext !important;
 
           * {
-            color: $headertext !important;
+            color: $headertext;
           }
         }
       }
@@ -288,9 +288,7 @@ function header_theme_settings_css(string $theme, string &$css, array $palette) 
     #block-dxpr-theme-main-menu {
      .dropdown-menu {
         .dropdown {
-          color: $dropdown_color_value !important;
-
-          * {
+           * {
             color: $dropdown_color_value !important;
           }
         }

--- a/scss/components/dxpr-theme-header.scss
+++ b/scss/components/dxpr-theme-header.scss
@@ -46,6 +46,16 @@
     }
   }
 
+  //.dxpr-theme-megamenu__heading {
+  //  color: dxpr-color('headertext') !important;
+  //}
+  //
+  //.dxpr-theme-megamenu {
+  //  a {
+  //    color: dxpr-color('headertext') !important;
+  //  }
+  //}
+
   .navbar-container {
     display: block;
     margin-bottom: 0;

--- a/scss/components/dxpr-theme-header.scss
+++ b/scss/components/dxpr-theme-header.scss
@@ -46,16 +46,6 @@
     }
   }
 
-  //.dxpr-theme-megamenu__heading {
-  //  color: dxpr-color('headertext') !important;
-  //}
-  //
-  //.dxpr-theme-megamenu {
-  //  a {
-  //    color: dxpr-color('headertext') !important;
-  //  }
-  //}
-
   .navbar-container {
     display: block;
     margin-bottom: 0;


### PR DESCRIPTION
## Linked issues

- #555 

## Solution

This PR introduces improvements to the handling of dropdown and menu text colors in the DXPR theme. Key changes include:

- Simplified conditional logic for setting dropdown and menu text colors.
- Added a resolve_color helper function for cleaner color resolution from the palette or custom settings.
- Ensured safe deserialization of color_palette using unserialize() with proper safeguards.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
