### PR TITLE
#562: Error updating 5.0 to 6.0.3 - dxpr_theme_post_update_n1_migrate_colors

### DIFF
--- a/dxpr_theme.post_update.php
+++ b/dxpr_theme.post_update.php
@@ -13,6 +13,10 @@ function dxpr_theme_post_update_n1_migrate_colors() {
   $theme_handler = \Drupal::service('theme_handler');
   $theme_list = $theme_handler->listInfo();
 
+  if (!\Drupal::moduleHandler()->moduleExists('color')) {
+    return t('The Color module is not installed.');
+  }
+
   // Load Color module.
   \Drupal::moduleHandler()->loadInclude('module', 'color');
 
@@ -29,20 +33,22 @@ function dxpr_theme_post_update_n1_migrate_colors() {
       $config = \Drupal::configFactory()
         ->getEditable($theme_name . '.settings');
 
-      // Get color module palette.
-      $color_palette = color_get_palette($theme_name);
-      $config->set('color_scheme', 'custom');
-      $config->set('color_palette', serialize($color_palette));
+      if (color_get_info($theme_name)) {
+        // Get color module palette.
+        $color_palette = color_get_palette($theme_name);
+        $config->set('color_scheme', 'custom');
+        $config->set('color_palette', serialize($color_palette));
 
-      foreach ($color_palette as $name => $clr) {
-        $config->set('color_palette_' . $name, $clr);
-      }
+        foreach ($color_palette as $name => $clr) {
+          $config->set('color_palette_' . $name, $clr);
+        }
 
-      $config->save();
+        $config->save();
 
-      // Rebuild theme CSS.
-      if (function_exists('dxpr_theme_css_cache_build')) {
-        dxpr_theme_css_cache_build($theme_name);
+        // Rebuild theme CSS.
+        if (function_exists('dxpr_theme_css_cache_build')) {
+          dxpr_theme_css_cache_build($theme_name);
+        }
       }
     }
   }

--- a/dxpr_theme_callbacks.inc
+++ b/dxpr_theme_callbacks.inc
@@ -26,6 +26,7 @@ function _dxpr_theme_css_cache_file($theme) {
  *
  * @param string $theme
  *   Theme machine name.
+ *
  * phpcs:ignore
  * @deprecated This function is no longer needed. Kept for legacy reasons.
  */

--- a/features/sooper-header/header-theme-settings-css.inc
+++ b/features/sooper-header/header-theme-settings-css.inc
@@ -239,18 +239,12 @@ function header_theme_settings_css(string $theme, string &$css, array $palette) 
    * This function returns the custom color if specified,
    * otherwise it fetches the color from the palette.
    */
-  function resolve_color($color, $custom_color, $color_palette) {
-    if ($color === 'custom') {
-      // Use the custom color.
-      return $custom_color;
-    }
-    // Safely access color from palette with null coalescing operator
-    return $color_palette[$color] ?? "dxpr-color('$color')";
-  }
+  $resolve_color = function ($color, $custom_color, $color_palette) {
+    return $color === 'custom' ? $custom_color : ($color_palette[$color] ?? "dxpr-color('$color')");
+  };
 
-  // Resolve dropdown and menu text colors using the helper function.
-  $dropdown_color_value = resolve_color($dropdown_text_color, $dropdown_custom_color, $color_palette);
-  $menu_color_value = resolve_color($menu_text_color, $menu_text_color_custom, $color_palette);
+  $dropdown_color_value = $resolve_color($dropdown_text_color, $dropdown_custom_color, $color_palette);
+  $menu_color_value = $resolve_color($menu_text_color, $menu_text_color_custom, $color_palette);
 
   if ($dropdown_text_color === '' && $menu_text_color === '') {
     // Handles the case where both dropdown and menu text colors are not set.

--- a/features/sooper-header/header-theme-settings-css.inc
+++ b/features/sooper-header/header-theme-settings-css.inc
@@ -228,17 +228,15 @@ function header_theme_settings_css(string $theme, string &$css, array $palette) 
   $menu_text_color = theme_get_setting('menu_text_color');
   $menu_text_color_custom = theme_get_setting('menu_text_color_custom');
 
-  // Add null check and provide default empty array
+  // Add null check and provide default empty array.
   $color_palette_setting = theme_get_setting('color_palette') ?? '';
   $color_palette = !empty($color_palette_setting) ? unserialize($color_palette_setting, ['allowed_classes' => FALSE]) : [];
 
-  // Safely access headertext with null coalescing operator
+  // Safely access headertext with null coalescing operator.
   $headertext = $color_palette['headertext'] ?? '';
 
-  /**
-   * This function returns the custom color if specified,
-   * otherwise it fetches the color from the palette.
-   */
+  // This function returns the custom color if specified,
+  // otherwise it fetches the color from the palette.
   $resolve_color = function ($color, $custom_color, $color_palette) {
     return $color === 'custom' ? $custom_color : ($color_palette[$color] ?? "dxpr-color('$color')");
   };


### PR DESCRIPTION
## Linked issues

- Fixes #562 

## Solution

1. Change nested function into an anonymous function to avoid global namespace clash.
2. Implement check for color module and color palette existence.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
