### PR TITLE
Fix #576: Retain custom colors when upgrading from DXPR Theme 5.x to 6.x

### DIFF
--- a/features/sooper-header/header-theme-settings-css.inc
+++ b/features/sooper-header/header-theme-settings-css.inc
@@ -235,22 +235,19 @@ function header_theme_settings_css(string $theme, string &$css, array $palette) 
   // Safely access headertext with null coalescing operator.
   $headertext = $color_palette['headertext'] ?? '';
 
-  /**
-   * This function returns the custom color if specified,
-   * otherwise it fetches the color from the palette.
-   *
-   * Guarded definition so it is only set once, even if this file is included multiple times.
-   */
   if (!isset($dxpr_resolve_color) || !is_callable($dxpr_resolve_color)) {
-    $dxpr_resolve_color = static function ($color, $custom_color, $color_palette) {
+    // Define color resolver once, even if this file is included multiple times.
+    $dxpr_resolve_color = static function (
+      $color,
+      $custom_color,
+      $color_palette,
+    ) {
       if ($color === 'custom' && is_string($custom_color) && $custom_color !== '') {
         return $custom_color;
       }
       return $color_palette[$color] ?? "dxpr-color('{$color}')";
     };
   }
-
-  // Alias for backward compatibility: rest of file still calls $resolve_color(...)
   $resolve_color = $dxpr_resolve_color;
 
   $dropdown_color_value = $resolve_color($dropdown_text_color, $dropdown_custom_color, $color_palette);

--- a/features/sooper-header/header-theme-settings-css.inc
+++ b/features/sooper-header/header-theme-settings-css.inc
@@ -235,11 +235,23 @@ function header_theme_settings_css(string $theme, string &$css, array $palette) 
   // Safely access headertext with null coalescing operator.
   $headertext = $color_palette['headertext'] ?? '';
 
-  // This function returns the custom color if specified,
-  // otherwise it fetches the color from the palette.
-  $resolve_color = function ($color, $custom_color, $color_palette) {
-    return $color === 'custom' ? $custom_color : ($color_palette[$color] ?? "dxpr-color('$color')");
-  };
+  /**
+   * This function returns the custom color if specified,
+   * otherwise it fetches the color from the palette.
+   *
+   * Guarded definition so it is only set once, even if this file is included multiple times.
+   */
+  if (!isset($dxpr_resolve_color) || !is_callable($dxpr_resolve_color)) {
+    $dxpr_resolve_color = static function ($color, $custom_color, $color_palette) {
+      if ($color === 'custom' && is_string($custom_color) && $custom_color !== '') {
+        return $custom_color;
+      }
+      return $color_palette[$color] ?? "dxpr-color('{$color}')";
+    };
+  }
+
+  // Alias for backward compatibility: rest of file still calls $resolve_color(...)
+  $resolve_color = $dxpr_resolve_color;
 
   $dropdown_color_value = $resolve_color($dropdown_text_color, $dropdown_custom_color, $color_palette);
   $menu_color_value = $resolve_color($menu_text_color, $menu_text_color_custom, $color_palette);

--- a/scss/dxpr-theme.admin.themesettings.scss
+++ b/scss/dxpr-theme.admin.themesettings.scss
@@ -318,6 +318,7 @@ $border-color: #222330;
 
     .vertical-tabs__panes {
       padding: 0 15px 15px 0;
+
       .details-wrapper {
         padding: 15px;
       }


### PR DESCRIPTION
## Linked issues

[576](https://github.com/dxpr/dxpr_theme/issues/576)

## Solution

Replaced direct `resolve_color` closure with a static `$dxpr_resolve_color` definition 
to prevent redeclare errors during upgrade. Ensures that custom colors defined in 
subthemes are retained when migrating from DXPR Theme 5.x to 6.x.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
