### PR TITLE
docs: clarify subtheme CSS file is for manual styles only

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ https://app.dxpr.com/hc/documentation/internal
 
 ## Contributing Guidelines
 
-Before you write any code for this project please also check 
+Before you write any code for this project please also check
 https://github.com/dxpr/dxpr_maven/blob/main/CONTRIBUTING.md
 
 ## [WARNING2] Save theme settings form after updating theme CSS
@@ -22,6 +22,18 @@ folder these changes might not take effect because the browser is loading
 the copies of the theme's CSS files from the files folder. To fix this you
 have to save the theme settings form so that the color module will create
 new copies of the theme's CSS files that include your latest changes.
+
+## Subtheme CSS File (/css/dxpr_theme_subtheme.css)
+
+**Important**: The `dxpr_theme_subtheme.css` file in your custom subtheme is intended
+**only for manual custom styles**. This file will remain empty by design and is not
+automatically populated when you change theme settings through the admin interface.
+
+### How it works:
+- All theme setting changes are applied directly from the parent theme
+- The `dxpr_theme_subtheme.css` file is included on the site but remains empty unless you manually add custom CSS
+- If you need custom styles, you must manually add them to `dxpr_theme_subtheme.css`
+- Manual styles in this file will persist even after saving theme settings and clearing cache
 
 # Continuous Integration / Automation
 


### PR DESCRIPTION
Addresses issue #3461290 - explains that dxpr_theme_subtheme.css is intentionally empty and meant only for manual custom styles.

## Linked issues

[The global styling css file dxpr_theme_subtheme.css is empty and the site has no styling](https://www.drupal.org/project/dxpr_theme/issues/3461290)

## Solution

Added documentation to README.md clarifying that the `dxpr_theme_subtheme.css` file in custom subthemes is intentionally empty and designed only for manual custom styles. This addresses user confusion where the empty CSS file was perceived as a bug. The documentation explains that theme settings changes are applied directly from the parent theme, and users must manually add custom CSS to the subtheme file if needed.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [x] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.