### PR TITLE
fix: only hide primary tabs for users with toolbar access

### DIFF
--- a/dxpr_theme.theme
+++ b/dxpr_theme.theme
@@ -283,8 +283,12 @@ function dxpr_theme_preprocess_menu_local_tasks(&$variables) {
     $show_local_tasks = $config->get('show_local_tasks');
 
     if ($show_local_tasks === TRUE) {
-      // Hide tabs when admin_toolbar_tools is showing local tasks.
-      $variables['hide_tabs'] = TRUE;
+      // Only hide tabs for users who have permission to access the toolbar.
+      $current_user = \Drupal::currentUser();
+      if ($current_user->hasPermission('access toolbar')) {
+        // Hide tabs when admin_toolbar_tools is showing local tasks.
+        $variables['hide_tabs'] = TRUE;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
Fixes a bug where primary tabs (local tasks) were hidden for all users when `admin_toolbar_tools` was configured to show local tasks, even for users who don't have permission to access the admin toolbar.

## Changes
- Added permission check in `dxpr_theme_preprocess_menu_local_tasks()` 
- Primary tabs are now only hidden for users with `access toolbar` permission
- Users without toolbar permissions continue to see the primary tabs since they can't see them in the admin toolbar

## Test plan
- [ ] Test with user who has toolbar access - tabs should be hidden when admin_toolbar_tools is configured
- [ ] Test with user without toolbar access - tabs should remain visible
- [ ] Verify admin_toolbar_tools configuration still works correctly for admin users

Closes #609

🤖 Generated with [Claude Code](https://claude.ai/code)