### PR TITLE
refactor: consolidate browser support config to use shared browserslist

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,12 +1,7 @@
 {
   "presets": [
     [
-      "@babel/preset-env",
-      {
-        "targets": {
-          "ie": "11"
-        }
-      }
+      "@babel/preset-env"
     ]
   ]
 

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,5 @@
 module.exports = {
   plugins: [
-    require('autoprefixer')({
-      overrideBrowserslist: ['> 1%', 'last 2 versions', 'Firefox ESR', 'not dead'],
-    })
+    require('autoprefixer')
   ]
 };


### PR DESCRIPTION
## Summary

- Consolidates browser support configuration to use shared browserslist from `package.json`
- Removes redundant browser target configs from `.babelrc` and `postcss.config.js`
- Ensures consistent browser targeting across all build tools (Babel, autoprefixer, webpack)

## Changes

- Removed explicit IE 11 target from `.babelrc` - now uses browserslist
- Removed `overrideBrowserslist` from `postcss.config.js` - now uses browserslist
- All tools now consistently use `package.json` browserslist: `"> 1%, last 4 versions"`

## Testing

Created test files and ran full build pipeline to verify:
- ✅ Autoprefixer adds correct vendor prefixes for targeted browsers
- ✅ Babel transpiles modern JS for targeted browsers
- ✅ All build tools read the shared browserslist configuration

## Related Issue

Closes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)