### PR TITLE
refactor: deprecate pull-down navbar header style

### DIFF
--- a/features/sooper-header/header-theme-settings-css.inc
+++ b/features/sooper-header/header-theme-settings-css.inc
@@ -80,21 +80,12 @@ function header_theme_settings_css(string $theme, string &$css, array $palette) 
     $css .= "}\n\n";
   }
 
-  if (theme_get_setting('header_style', $theme) == 'navbar_pull_down') {
-    $css .= ".body--dxpr-theme-nav-desktop.body--dxpr-theme-header-not-overlay .dxpr-theme-header--top .col-sm-12 {\n";
-    $css .= "  margin-bottom: calc(-1 * $header_top_height_var / 2);\n";
-    $css .= "}\n\n";
-  }
-
   // Sticky footer settings.
   if (theme_get_setting('sticky_footer', $theme)) {
     $header_top_height = $header_top_height_var;
 
     if (theme_get_setting('header_top_layout', $theme) == 'centered') {
       $header_top_height = "calc($header_top_height_var * 2)";
-    }
-    if (theme_get_setting('header_style', $theme) == 'navbar_pull_down') {
-      $header_top_height = "calc($header_top_height_var / 2)";
     }
 
     $css .= ".html--dxpr-theme-sticky-footer .body--dxpr-theme-nav-desktop .dxpr-theme-header--top {\n";

--- a/features/sooper-header/header-theme-settings.inc
+++ b/features/sooper-header/header-theme-settings.inc
@@ -44,15 +44,21 @@ function header_theme_settings(array &$form, $theme) {
     ],
   ];
 
+  // Normalize header_style value - treat deprecated values as 'normal'.
+  $header_style = theme_get_setting('header_style');
+  $valid_header_styles = ['normal', 'overlay'];
+  if (!in_array($header_style, $valid_header_styles, TRUE)) {
+    $header_style = 'normal';
+  }
+
   $form['dxpr_theme_settings']['header']['header_top']['header_style'] = [
     '#type' => 'radios',
     '#title' => t('Header Style'),
     '#description' => t('Create transparent headers and free floating navbars. Overlays the header over the page title and content.'),
-    '#default_value' => ((theme_get_setting('header_style') !== NULL)) ? theme_get_setting('header_style') : 'normal',
+    '#default_value' => $header_style,
     '#options' => [
       'normal' => t('Normal'),
       'overlay' => t('Overlay'),
-      'navbar_pull_down' => t('Pull-down Navbar'),
     ],
   ];
 

--- a/js/dist/header/hit-detection.js
+++ b/js/dist/header/hit-detection.js
@@ -2,7 +2,7 @@
  * @function hitDetection
  * Adjusts the margin of the primary tabs to avoid overlap with the header elements.
  * This function calculates and applies a margin-top to the `.tabs--primary` element
- * based on its bounding rectangle and the position of the navbar or pull-down container.
+ * based on its bounding rectangle and the position of the navbar.
  *
  * Dependencies:
  * - dxprThemeCollisionCheck: A helper function to detect rectangle intersection.
@@ -16,33 +16,15 @@ function hitDetection() {
     .querySelector(".tabs--primary")
     .getBoundingClientRect();
 
-  // Check if navbar pull-down elements are present
-  if (
-    document.querySelectorAll(".dxpr-theme-header--navbar-pull-down").length >
-      0 &&
-    document.querySelectorAll("#navbar .container-col").length > 0
-  ) {
-    // Get the bounding rectangle of the pull-down container
-    const pullDownRect = document
-      .querySelector("#navbar .container-col")
-      .getBoundingClientRect();
+  // Get the bounding rectangle of the main navbar
+  const navbarRect = document
+    .querySelector("#navbar")
+    .getBoundingClientRect();
 
-    // If pull-down overlaps with tabs, adjust margin-top of the tabs
-    if (dxprThemeCollisionCheck(pullDownRect, tabsRect)) {
-      document.querySelector(".tabs--primary").style.marginTop =
-        `${pullDownRect.bottom - tabsRect.top + 6}px`;
-    }
-  } else {
-    // Fallback: Get the bounding rectangle of the main navbar if pull-down is absent
-    const navbarRect = document
-      .querySelector("#navbar")
-      .getBoundingClientRect();
-
-    // If navbar overlaps with tabs, adjust margin-top of the tabs
-    if (dxprThemeCollisionCheck(navbarRect, tabsRect)) {
-      document.querySelector(".tabs--primary").style.marginTop =
-        `${navbarRect.bottom - tabsRect.top + 6}px`;
-    }
+  // If navbar overlaps with tabs, adjust margin-top of the tabs
+  if (dxprThemeCollisionCheck(navbarRect, tabsRect)) {
+    document.querySelector(".tabs--primary").style.marginTop =
+      `${navbarRect.bottom - tabsRect.top + 6}px`;
   }
 }
 

--- a/scss/base/layout.scss
+++ b/scss/base/layout.scss
@@ -304,10 +304,6 @@ body .card.node--view-mode-card img {
     flex: 1 0 auto;
   }
 
-  .body--dxpr-theme-nav-desktop .dxpr-theme-header--top.dxpr-theme-header--navbar-pull-down {
-    min-height: 45px;
-  }
-
   .body--dxpr-theme-nav-desktop .dxpr-theme-header--top.affix {
     min-height: 60px;
   }

--- a/scss/components/dxpr-theme-header--top.scss
+++ b/scss/components/dxpr-theme-header--top.scss
@@ -65,12 +65,6 @@
       }
     }
 
-    &.dxpr-theme-header--navbar-pull-down {
-      .container-row > .col-sm-12 {
-        background: dxpr-color('header');
-      }
-    }
-
     &.affix {
       left: 0;
       opacity: 1;

--- a/scss/components/dxpr-theme-header.scss
+++ b/scss/components/dxpr-theme-header.scss
@@ -7,8 +7,6 @@
 }
 
 .body--dxpr-theme-nav-desktop {
-  // extra z-indexing for pull-down header that needs to cover slider
-  // this should not be active in mobile mode due to owl carousel layout bugs
   .navbar-container > .row > .col-sm-12 {
     position: relative;
     z-index: 405;


### PR DESCRIPTION
## Summary
Removes the deprecated 'Pull-down Navbar' header style option from theme settings. Sites currently using this style will automatically fall back to 'Normal' header style with no manual intervention required.

## Changes
- ✅ Removed 'Pull-down Navbar' option from `header_style` form field
- ✅ Added normalization logic to treat deprecated/invalid values as 'normal'
- ✅ Removed CSS generation for pull-down navbar styles
- ✅ Removed SCSS styles for `.dxpr-theme-header--navbar-pull-down` class
- ✅ Simplified JavaScript hit detection logic (removed pull-down-specific checks)
- ✅ Cleaned up comments referencing pull-down functionality

## Migration Strategy
No migration code or post-update hooks needed. The implementation gracefully handles legacy configurations:

1. **Form display**: Legacy values are normalized to 'normal' when the settings form loads
2. **CSS generation**: Code only checks for 'normal' and 'overlay' - invalid values are ignored
3. **JavaScript**: Simplified logic removes pull-down-specific detection

Sites with the deprecated setting will see no visual difference as the pull-down style falls back to normal header behavior.

## Test Plan
- [ ] Verify theme settings form displays correctly with 'Normal' and 'Overlay' options only
- [ ] Test that existing sites with pull-down setting show normal header
- [ ] Confirm JavaScript hit detection works correctly
- [ ] Rebuild CSS and verify no pull-down styles remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)