### PR TITLE
fix: show secondary tabs when admin_toolbar_tools hides primary tabs

### DIFF
--- a/templates/menu-local-tasks.html.twig
+++ b/templates/menu-local-tasks.html.twig
@@ -6,7 +6,8 @@
  * Available variables:
  * - primary: HTML list items representing primary tasks.
  * - secondary: HTML list items representing primary tasks.
- * - hide_tabs: Boolean to conditionally hide tabs when admin_toolbar_tools shows local tasks.
+ * - hide_tabs: Boolean to conditionally hide primary tabs when admin_toolbar_tools shows local tasks.
+ *   Secondary tabs are always shown since they are not displayed in the admin toolbar.
  *
  * Each item in these variables (primary and secondary) can be individually
  * themed in menu-local-task.html.twig.
@@ -17,17 +18,17 @@
  */
 #}
 
-{% if not hide_tabs %}
+{% if (primary and not hide_tabs) or secondary %}
   {{ attach_library('dxpr_theme/drupal-tabs') }}
+{% endif %}
 
-  {% if primary %}
-    <div class="dxpr-theme-mini-tabs-wrapper" data-drupal-nav-primary-tabs>
-      <h2 class="visually-hidden">{{ 'Primary tabs'|t }}</h2>
-      <ul class="tabs tabs--primary nav nav-tabs">{{ primary }}</ul>
-    </div>
-  {% endif %}
-  {% if secondary %}
-    <h2 class="visually-hidden">{{ 'Secondary tabs'|t }}</h2>
-    <ul class="tabs tabs--secondary pagination pagination-sm">{{ secondary }}</ul>
-  {% endif %}
+{% if primary and not hide_tabs %}
+  <div class="dxpr-theme-mini-tabs-wrapper" data-drupal-nav-primary-tabs>
+    <h2 class="visually-hidden">{{ 'Primary tabs'|t }}</h2>
+    <ul class="tabs tabs--primary nav nav-tabs">{{ primary }}</ul>
+  </div>
+{% endif %}
+{% if secondary %}
+  <h2 class="visually-hidden">{{ 'Secondary tabs'|t }}</h2>
+  <ul class="tabs tabs--secondary pagination pagination-sm">{{ secondary }}</ul>
 {% endif %}


### PR DESCRIPTION
## Linked issues

- #643

## Solution

When admin_toolbar_tools is configured to show local tasks in the toolbar, the theme now only hides primary tabs (which appear in the toolbar) while keeping secondary tabs visible (which don't appear in the toolbar).

The template was updated to conditionally render primary and secondary tabs independently, ensuring users with toolbar access don't lose access to secondary navigation.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_theme/blob/6.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.