### PR TITLE
fix: remove hardcoded container max-width values (#3556040)

### DIFF
--- a/scss/components/dxpr-theme-header.scss
+++ b/scss/components/dxpr-theme-header.scss
@@ -2,10 +2,6 @@
 // @see layout-theme-settings-css.inc
 @import "../includes/variables";
 
-.html .navbar.container {
-  max-width: 1600px;
-}
-
 .body--dxpr-theme-nav-desktop {
   .navbar-container > .row > .col-sm-12 {
     position: relative;

--- a/scss/vendor-extensions/bootstrap-5.scss
+++ b/scss/vendor-extensions/bootstrap-5.scss
@@ -30,7 +30,6 @@ html body {
   }
 
   .container {
-    max-width: 1600px;
     width: 100%;
 
     .container {


### PR DESCRIPTION
## Linked issues

- Drupal.org: https://www.drupal.org/project/dxpr_theme/issues/3556040

## Solution

Removed hardcoded `max-width: 1600px` values from `bootstrap-5.scss` and `dxpr-theme-header.scss` that were overriding the `layout_max_width` theme setting due to higher CSS specificity.

### Root Cause
Container max-width styles were scattered across 3 files:
1. `scss/base/layout.scss` - Using CSS variable (correct)
2. `scss/vendor-extensions/bootstrap-5.scss` - Hardcoded 1600px override
3. `scss/components/dxpr-theme-header.scss` - Hardcoded navbar override

The `.html .container` selectors had higher specificity than `.container`, causing the hardcoded values to win and making the theme setting non-functional.

### Changes
- **bootstrap-5.scss**: Removed `max-width: 1600px` from `.html .container` rule, kept `width: 100%` for Bootstrap fluid behavior
- **dxpr-theme-header.scss**: Removed entire `.html .navbar.container` rule with hardcoded max-width

This establishes `scss/base/layout.scss` as the single source of truth for container max-width using the `--dxt-setting-layout-max-width` CSS variable.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.