### PR TITLE
Fix duplicate Bootstrap loading when cdn_provider not configured

### DIFF
--- a/dxpr_theme.theme
+++ b/dxpr_theme.theme
@@ -47,10 +47,13 @@ function dxpr_theme_library_info_alter(&$libraries, $extension) {
  * See the html.html.twig template for the list of variables.
  */
 function dxpr_theme_preprocess_html(&$variables) {
-  // If bootstrap basetheme is not loading bootstrap from CDN load it locally
+  // Only load local Bootstrap when cdn_provider is explicitly set to empty
+  // string, meaning Bootstrap base theme is configured to NOT load from CDN.
+  // When cdn_provider is not set, Bootstrap base theme uses its default
+  // 'jsdelivr' and will load Bootstrap from CDN, so we should not duplicate.
   // This is default behavior starting from DXPR Theme 8.x-1.1.3 and 7.x-2.7.3.
   $bootstrap_cdn = theme_get_setting('cdn_provider');
-  if (!$bootstrap_cdn) {
+  if ($bootstrap_cdn === '') {
     $variables['#attached']['library'][] = 'dxpr_theme/bootstrap3';
   }
 


### PR DESCRIPTION
## Linked issues

- #666

## Solution

Change the condition in `dxpr_theme_preprocess_html()` from `if (!$bootstrap_cdn)` to `if ($bootstrap_cdn === '')`.

When `cdn_provider` is not set in config, `theme_get_setting()` returns `null`. The previous check treated `null` as falsy and loaded local Bootstrap. But Bootstrap base theme uses its annotation default `'jsdelivr'` and also loads CDN Bootstrap, causing duplicates.

The strict equality check `=== ''` ensures local Bootstrap only loads when `cdn_provider` is **explicitly** set to empty string (meaning admin intentionally disabled CDN), not when it's simply unconfigured (meaning Bootstrap base theme should handle it with its default).

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_theme/blob/1.x/CONTRIBUTING.md) document.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.