### PR TITLE
Fix CI: Use docker compose v2 syntax

### DIFF
--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -10,11 +10,11 @@ jobs:
   drupal-lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Lint Drupal
       run: |
-        TARGET_DRUPAL_CORE_VERSION=$TARGET_DRUPAL_CORE_VERSION docker-compose run --rm drupal-lint
+        TARGET_DRUPAL_CORE_VERSION=$TARGET_DRUPAL_CORE_VERSION docker compose run --rm drupal-lint
 
   # eslint:
   #   runs-on: ubuntu-latest


### PR DESCRIPTION
## Linked issues

- #668

## Solution

Update `.github/workflows/review.yaml` to use Docker Compose v2 syntax:
- Change `docker-compose` to `docker compose` (v2 plugin, without hyphen)
- Update `actions/checkout` from v2 to v4

GitHub Actions `ubuntu-latest` runners no longer include `docker-compose` v1 standalone binary, only the `docker compose` v2 plugin.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_theme/blob/1.x/CONTRIBUTING.md) document.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.