### PR TITLE
fix: handle string URLs in menu active trail detection

### DIFF
--- a/dxpr_theme.theme
+++ b/dxpr_theme.theme
@@ -319,7 +319,9 @@ function dxpr_theme_menu_set_active_trail(array &$items, $current_path) {
     $child_active = FALSE;
 
     try {
-      $item_path = $item['url']->toString();
+      $item_path = $item['url'] instanceof \Drupal\Core\Url
+        ? $item['url']->toString()
+        : (string) $item['url'];
       if ($item_path === $current_path) {
         $item['in_active_trail'] = TRUE;
         $item['is_active'] = TRUE;

--- a/dxpr_theme.theme
+++ b/dxpr_theme.theme
@@ -7,6 +7,7 @@
  * Place your custom PHP code in this file.
  */
 
+use Drupal\Core\Url;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\media\Entity\Media;
 use Drupal\Component\Utility\Html;
@@ -319,8 +320,8 @@ function dxpr_theme_menu_set_active_trail(array &$items, $current_path) {
     $child_active = FALSE;
 
     try {
-      $item_path = $item['url'] instanceof \Drupal\Core\Url
-        ? $item['url']->toString()
+      $item_path = $item['url'] instanceof
+      Url ? $item['url']->toString()
         : (string) $item['url'];
       if ($item_path === $current_path) {
         $item['in_active_trail'] = TRUE;

--- a/features/sooper-header/header-theme-settings.inc
+++ b/features/sooper-header/header-theme-settings.inc
@@ -527,7 +527,6 @@ function header_theme_settings(array &$form, $theme) {
 
   // Deprecated: This setting is no longer used. Menu items with children are
   // always marked with visual indicators (carets) for accessibility.
-
   $form['dxpr_theme_settings']['header']['menu']['dropdown_width_auto'] = [
     '#type' => 'radios',
     '#title' => t('Dropdown width'),


### PR DESCRIPTION
## Linked issues

- #682

## Solution

Add type check before calling `toString()` on menu item URLs in `dxpr_theme_menu_set_active_trail()`.

Some menu items may have string URLs instead of `\Drupal\Core\Url` objects (e.g., from certain contrib modules or special menu link types), which caused a fatal error:

```
Error: Call to a member function toString() on string
```

The fix checks if `$item['url']` is a `Url` object before calling `->toString()`, and falls back to casting to string otherwise.

This does not affect the workaround for Drupal core issue #3359511 - it simply makes it more robust.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.