### PR TITLE
fix: escape < character in mobile gutter description text

### DIFF
--- a/features/sooper-layout/layout-theme-settings.inc
+++ b/features/sooper-layout/layout-theme-settings.inc
@@ -212,7 +212,7 @@ function layout_theme_settings(array &$form, $theme) {
     '#min' => 0,
     '#max' => 100,
     '#step' => 1,
-    '#description' => t('Width of the horizontal gutter in DXPR Theme mobile view (<1200px). 0 - 100px. Default is 10.'),
+    '#description' => t('Width of the horizontal gutter in DXPR Theme mobile view (under 1200px). 0 - 100px. Default is 10.'),
     '#attributes' => [
       'class' => ['dxb-slider', 'gutter-horizontal-mobile-range'],
       'data-dxb-slider' => TRUE,
@@ -226,7 +226,7 @@ function layout_theme_settings(array &$form, $theme) {
     '#min' => 0,
     '#max' => 100,
     '#step' => 1,
-    '#description' => t('Width of the vertical gutter in DXPR Theme mobile view (<1200px). 0 - 100px. Default is 10px.'),
+    '#description' => t('Width of the vertical gutter in DXPR Theme mobile view (under 1200px). 0 - 100px. Default is 10px.'),
     '#attributes' => [
       'class' => ['dxb-slider', 'gutter-vertical-mobile-range'],
       'data-dxb-slider' => TRUE,


### PR DESCRIPTION
## Linked issues

- #684

## Solution

Replace `(<1200px)` with `(under 1200px)` in the description text for `gutter_horizontal_mobile` and `gutter_vertical_mobile` fields to prevent the `<` character from being interpreted as an HTML tag.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.