### PR TITLE
Improve UI text quality and consistency in theme settings

### DIFF
--- a/features/sooper-block-design/block-design-theme-settings.inc
+++ b/features/sooper-block-design/block-design-theme-settings.inc
@@ -95,7 +95,7 @@ function block_design_theme_settings(array &$form, $theme) {
 
   $form['dxpr_theme_settings']['block']['block_advanced']['block_el']['block_padding'] = [
     '#type' => 'range',
-    '#title' => t('Block padding'),
+    '#title' => t('Block Padding'),
     '#default_value' => ((theme_get_setting('block_padding') !== NULL)) ? theme_get_setting('block_padding') : 0,
     '#min' => 0,
     '#max' => 30,
@@ -229,7 +229,7 @@ function block_design_theme_settings(array &$form, $theme) {
 
   $form['dxpr_theme_settings']['block']['block_advanced']['title_el']['title_padding'] = [
     '#type' => 'range',
-    '#title' => t('Title padding'),
+    '#title' => t('Title Padding'),
     '#default_value' => ((theme_get_setting('title_padding') !== NULL)) ? theme_get_setting('title_padding') : 10,
     '#min' => 0,
     '#max' => 30,
@@ -325,7 +325,7 @@ function block_design_theme_settings(array &$form, $theme) {
     '#type' => 'checkbox',
     '#title' => t('Title Sticker Mode'),
     '#default_value' => ((theme_get_setting('title_sticker') !== NULL)) ? theme_get_setting('title_sticker') : 0,
-    '#description' => t("In Sticker mode the title's width is flexible. By default the title takes the full width of the block"),
+    '#description' => t("When enabled, the title width adjusts to fit its content instead of spanning the full block width."),
     '#prefix' => '<br>',
   ];
 
@@ -345,7 +345,7 @@ function block_design_theme_settings(array &$form, $theme) {
   $form['dxpr_theme_settings']['block']['block_advanced']['divider_el']['block_divider_custom'] = [
     '#type' => 'checkbox',
     '#title' => t('Customize Divider'),
-    '#description' => t('Turn on to customize block divider specifically. To customize the divider default styling globally across the website find the Divider settings in the Typography tab.'),
+    '#description' => t('Override the global divider styles from the Typography tab for this block only.'),
     '#default_value' => ((theme_get_setting('block_divider_custom') !== NULL)) ? theme_get_setting('block_divider_custom') : 0,
     '#states' => [
       'visible' => [
@@ -454,7 +454,7 @@ function block_design_theme_settings(array &$form, $theme) {
     '#type' => 'details',
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
-    '#description' => t('The custom block design only applies to selected regions.'),
+    '#description' => t('Block design styles only apply to selected regions.'),
     '#suffix' => '</div></div>',
   ];
 

--- a/features/sooper-colors/colors-theme-settings.inc
+++ b/features/sooper-colors/colors-theme-settings.inc
@@ -52,7 +52,7 @@ function colors_theme_settings(array &$form, $theme) {
 
   $form['dxpr_theme_settings']['colors']['wrapper']['color_scheme'] = [
     '#type' => 'select',
-    '#title' => t('Color set'),
+    '#title' => t('Color Set'),
     '#default_value' => theme_get_setting('color_scheme') ?? 'default',
     '#options' => $scheme_options,
   ];

--- a/features/sooper-custom-css/custom-css-theme-settings.inc
+++ b/features/sooper-custom-css/custom-css-theme-settings.inc
@@ -18,7 +18,7 @@ function custom_css_theme_settings(array &$form, $theme) {
     '#title' => t('Custom CSS & JS'),
     '#type' => 'details',
     '#group' => 'dxpr_theme_settings',
-    '#description' => t("This CSS will be attached after the theme and allows you to customize your site without needing the additional complexity of a subtheme."),
+    '#description' => t("Add custom CSS and JavaScript without creating a subtheme."),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
     '#weight' => 30,
@@ -33,7 +33,7 @@ function custom_css_theme_settings(array &$form, $theme) {
 
   $form['dxpr_theme_settings']['custom_css']['custom_javascript_site'] = [
     '#type' => 'textarea',
-    '#title' => t('Sitewide Javascript (include script tags)'),
+    '#title' => t('Sitewide JavaScript'),
     '#default_value' => theme_get_setting('custom_javascript_site'),
     '#rows' => 15,
   ];

--- a/features/sooper-fonts/fonts-theme-settings.inc
+++ b/features/sooper-fonts/fonts-theme-settings.inc
@@ -31,7 +31,7 @@ function fonts_theme_settings(array &$form, $theme) {
   // Regular Fonts Settings.
   $form['dxpr_theme_settings']['fonts']['body_font_face'] = [
     '#type' => 'select',
-    '#title' => t('Base font'),
+    '#title' => t('Base Font'),
     '#default_value' => theme_get_setting('body_font_face'),
     '#options' => $font_list,
     '#prefix' => '<p>' . t('Choose from @count webfonts', ['@count' => $font_count]) . '</p>',
@@ -71,7 +71,7 @@ function fonts_theme_settings(array &$form, $theme) {
 
   $form['dxpr_theme_settings']['fonts']['sitename_font_face'] = [
     '#type' => 'select',
-    '#title' => t('Site name'),
+    '#title' => t('Site Name'),
     '#default_value' => theme_get_setting('sitename_font_face'),
     '#options' => $font_list,
   ];

--- a/features/sooper-header/header-theme-settings.inc
+++ b/features/sooper-header/header-theme-settings.inc
@@ -41,7 +41,6 @@ function header_theme_settings(array &$form, $theme) {
   $form['dxpr_theme_settings']['header']['header_top']['header_top_layout'] = [
     '#type' => 'radios',
     '#title' => t('Layout'),
-    '#description' => t('Different header layouts give a different view at your menu and logo.'),
     '#default_value' => ((theme_get_setting('header_top_layout') !== NULL)) ? theme_get_setting('header_top_layout') : '0',
     '#options' => [
       '0' => t('Normal (Logo left, Menu Right)'),
@@ -64,7 +63,7 @@ function header_theme_settings(array &$form, $theme) {
   $form['dxpr_theme_settings']['header']['header_top']['header_style'] = [
     '#type' => 'radios',
     '#title' => t('Header Style'),
-    '#description' => t('Create transparent headers and free floating navbars. Overlays the header over the page title and content.'),
+    '#description' => t('Overlay mode places the header over page content, allowing transparent backgrounds.'),
     '#default_value' => $header_style,
     '#options' => [
       'normal' => t('Normal'),
@@ -79,7 +78,7 @@ function header_theme_settings(array &$form, $theme) {
     '#min' => 0,
     '#max' => 1,
     '#step' => 0.01,
-    '#description' => t('Creates RGBa translucent background color. 0 is fully transparent and 1 is fully opaque.'),
+    '#description' => t('0 = transparent, 1 = opaque.'),
     '#attributes' => [
       'class' => ['dxb-slider', 'header-top-bg-opacity-range'],
       'data-dxb-slider' => TRUE,
@@ -93,7 +92,7 @@ function header_theme_settings(array &$form, $theme) {
     '#min' => 10,
     '#max' => 200,
     '#step' => 1,
-    '#description' => t('Initial height of the header. 10px - 200px. Default is 100.'),
+    '#description' => t('Initial height of the header.'),
     '#attributes' => [
       'class' => ['dxb-slider', 'header-top-height-range'],
       'data-dxb-slider' => TRUE,
@@ -107,7 +106,7 @@ function header_theme_settings(array &$form, $theme) {
     '#min' => 10,
     '#max' => 100,
     '#step' => 1,
-    '#description' => t('Height of the logo within the header. 10% - 100%. Default is 50%.'),
+    '#description' => t('Logo height as percentage of the header height.'),
     '#attributes' => [
       'class' => ['dxb-slider', 'logo-height-range'],
       'data-dxb-slider' => TRUE,
@@ -118,14 +117,14 @@ function header_theme_settings(array &$form, $theme) {
     '#type' => 'checkbox',
     '#title' => t('Fixed Position'),
     '#default_value' => ((theme_get_setting('header_top_fixed') !== NULL)) ? theme_get_setting('header_top_fixed') : FALSE,
-    '#description' => t('A Fixed header stays in the top of the browser when a user scrolls.'),
+    '#description' => t('Header stays visible at the top when scrolling.'),
   ];
 
   $form['dxpr_theme_settings']['header']['header_top']['header_top_sticky'] = [
     '#type' => 'checkbox',
     '#title' => t('Sticky Header'),
     '#default_value' => ((theme_get_setting('header_top_sticky') !== NULL)) ? theme_get_setting('header_top_sticky') : FALSE,
-    '#description' => t('A sticky can first be positioned at a distance from the top edge of the window and when the user scrolls past a certain point it will stick to the top of the window.'),
+    '#description' => t('Header appears after scrolling past a specified offset.'),
     '#states' => [
       'visible' => [
         ':input[name="header_top_fixed"]' => ['checked' => TRUE],
@@ -137,7 +136,6 @@ function header_theme_settings(array &$form, $theme) {
     '#type' => 'checkbox',
     '#title' => t('Sticky Second Header'),
     '#default_value' => ((theme_get_setting('second_header_sticky') !== NULL)) ? theme_get_setting('second_header_sticky') : FALSE,
-    '#description' => t('A sticky can first be positioned at a distance from the top edge of the window and when the user scrolls past a certain point it will stick to the top of the window.'),
     '#states' => [
       'visible' => [
         ':input[name="header_style"]' => ['value' => 'overlay'],
@@ -167,7 +165,7 @@ function header_theme_settings(array &$form, $theme) {
       'always' => t('Always Show'),
       'after_scroll' => t('Hide initially. Show after scroll offset'),
     ],
-    '#description' => t('Hide menu before or after scrolling. Turn on "Overlay Mode" to prevent your menu creating an empty space at the top of your layout.'),
+    '#description' => t('Use Overlay mode to prevent empty space at the top when hidden initially.'),
     '#states' => [
       'visible' => [
         ':input[name="header_top_fixed"]' => ['checked' => TRUE],
@@ -183,7 +181,7 @@ function header_theme_settings(array &$form, $theme) {
     '#min' => 0,
     '#max' => 2096,
     '#step' => 10,
-    '#description' => t('Scroll distance before header jumps to its fixed position at the top of page. 0 - 2096px. Default is 60.'),
+    '#description' => t('Scroll distance before header becomes fixed.'),
     '#states' => [
       'visible' => [
         ':input[name="header_top_fixed"]' => ['checked' => TRUE],
@@ -203,7 +201,7 @@ function header_theme_settings(array &$form, $theme) {
     '#min' => 10,
     '#max' => 200,
     '#step' => 1,
-    '#description' => t('Header height after scrolling past scroll offset. Default is 50.'),
+    '#description' => t('Header height after scrolling past scroll offset.'),
     '#states' => [
       'visible' => [
         ':input[name="header_top_fixed"]' => ['checked' => TRUE],
@@ -223,7 +221,7 @@ function header_theme_settings(array &$form, $theme) {
     '#min' => 0,
     '#max' => 1,
     '#step' => 0.01,
-    '#description' => t('Creates RGBa translucent background color. 0 is fully transparent and 1 is fully opaque.'),
+    '#description' => t('0 = transparent, 1 = opaque.'),
     '#states' => [
       'visible' => [
         ':input[name="header_top_fixed"]' => ['checked' => TRUE],
@@ -486,19 +484,17 @@ function header_theme_settings(array &$form, $theme) {
 
   $form['dxpr_theme_settings']['header']['header_side']['hamburger_menu'] = [
     '#type' => 'radios',
-    '#title' => t('Hamburger Menu'),
-    '#description' => t('Hamburger menu.'),
+    '#title' => t('Hamburger Icon Style'),
     '#default_value' => ((theme_get_setting('hamburger_menu') !== NULL)) ? theme_get_setting('hamburger_menu') : 'three-dash',
     '#options' => [
-      'three-dash' => t('Three dash'),
-      'two-dash' => t('Two dash'),
+      'three-dash' => t('Three lines'),
+      'two-dash' => t('Two lines'),
     ],
   ];
 
   $form['dxpr_theme_settings']['header']['header_side']['hamburger_animation'] = [
     '#type' => 'radios',
     '#title' => t('Hamburger Animation'),
-    '#description' => t('Hamburger Animation.'),
     '#default_value' => ((theme_get_setting('hamburger_animation') !== NULL)) ? theme_get_setting('hamburger_animation') : 'cross',
     '#options' => [
       'none' => t('None'),
@@ -509,7 +505,6 @@ function header_theme_settings(array &$form, $theme) {
   $form['dxpr_theme_settings']['header']['header_side']['header_side_align'] = [
     '#type' => 'radios',
     '#title' => t('Mobile Menu Alignment'),
-    '#description' => t('Control the alignment of mobile menu content.'),
     '#default_value' => ((theme_get_setting('header_side_align') !== NULL)) ? theme_get_setting('header_side_align') : 'left',
     '#options' => [
       'left' => t('Left'),
@@ -529,7 +524,7 @@ function header_theme_settings(array &$form, $theme) {
   // always marked with visual indicators (carets) for accessibility.
   $form['dxpr_theme_settings']['header']['menu']['dropdown_width_auto'] = [
     '#type' => 'radios',
-    '#title' => t('Dropdown width'),
+    '#title' => t('Dropdown Width'),
     '#default_value' => ((theme_get_setting('dropdown_width_auto') !== NULL)) ? theme_get_setting('dropdown_width_auto') : '1',
     '#options' => [
       '1' => t('Automatic (fits content)'),
@@ -539,7 +534,7 @@ function header_theme_settings(array &$form, $theme) {
 
   $form['dxpr_theme_settings']['header']['menu']['dropdown_width'] = [
     '#type' => 'range',
-    '#title' => t('Fixed dropdown width'),
+    '#title' => t('Fixed Dropdown Width'),
     '#title_display' => 'invisible',
     '#default_value' => ((theme_get_setting('dropdown_width') !== NULL)) ? theme_get_setting('dropdown_width') : '200',
     '#min' => 100,
@@ -693,7 +688,7 @@ function header_theme_settings(array &$form, $theme) {
     '#min' => 480,
     '#max' => 4100,
     '#step' => 10,
-    '#description' => t('Point below where DXPR Theme switches to mobile header and navigation. If you set this to the maximum value (4100) the desktop style will never show. Default is 1200.'),
+    '#description' => t('Viewport width below which mobile header is used. Set to maximum (4100) to always use mobile style.'),
     '#attributes' => [
       'class' => ['dxb-slider', 'header-mobile-breakpoint-range'],
       'data-dxb-slider' => TRUE,
@@ -707,7 +702,7 @@ function header_theme_settings(array &$form, $theme) {
     '#min' => 10,
     '#max' => 200,
     '#step' => 1,
-    '#description' => t('Height of header in mobile view. 10px - 200px. Default is 60.'),
+    '#description' => t('Height of header in mobile view.'),
     '#attributes' => [
       'class' => ['dxb-slider', 'header-mobile-height-range'],
       'data-dxb-slider' => TRUE,
@@ -718,6 +713,6 @@ function header_theme_settings(array &$form, $theme) {
     '#type' => 'checkbox',
     '#title' => t('Fixed Position'),
     '#default_value' => ((theme_get_setting('header_mobile_fixed') !== NULL)) ? theme_get_setting('header_mobile_fixed') : FALSE,
-    '#description' => t('A Fixed header stays in the top of the browser when a user scrolls.'),
+    '#description' => t('Header stays visible at the top when scrolling.'),
   ];
 }

--- a/features/sooper-layout/layout-theme-settings.inc
+++ b/features/sooper-layout/layout-theme-settings.inc
@@ -25,14 +25,14 @@ function layout_theme_settings(array &$form, $theme) {
     '#type' => 'checkbox',
     '#title' => t('Boxed Layout'),
     '#default_value' => ((theme_get_setting('boxed_layout') !== NULL)) ? theme_get_setting('boxed_layout') : 1,
-    '#description' => t('By default containers and their backgrounds are full-width. Boxed containers will squeeze all container backgrounds into a centered column.'),
+    '#description' => t('When enabled, all container backgrounds are constrained to a centered column instead of spanning full width.'),
   ];
 
   $form['dxpr_theme_settings']['layout']['sticky_footer'] = [
     '#type' => 'checkbox',
     '#title' => t('Sticky Footer'),
     '#default_value' => ((theme_get_setting('sticky_footer') !== NULL)) ? theme_get_setting('sticky_footer') : 1,
-    '#description' => t('Makes footer stick to the bottom of the browser on short pages. (Does not work with boxed layout)'),
+    '#description' => t('Keeps the footer at the bottom of the viewport on short pages. Not compatible with boxed layout.'),
     '#states' => [
       'visible' => [
         ':input[name="boxed_layout"]' => ['checked' => FALSE],
@@ -44,7 +44,7 @@ function layout_theme_settings(array &$form, $theme) {
     '#type' => 'textfield',
     '#title' => t('Box Background'),
     '#default_value' => ((theme_get_setting('boxed_layout_boxbg') !== NULL)) ? theme_get_setting('boxed_layout_boxbg') : '#ffffff',
-    '#description' => t('Background color for main content while in boxed mode'),
+    '#description' => t('Background color for the main content area in boxed mode.'),
     '#states' => [
       'visible' => [
         ':input[name="boxed_layout"]' => ['checked' => TRUE],
@@ -69,7 +69,7 @@ function layout_theme_settings(array &$form, $theme) {
       '#min' => 480,
       '#max' => 4100,
       '#step' => 10,
-      '#description' => t('Width of the boxed layout container. Should be higher than content width.'),
+      '#description' => t('Maximum width of the boxed layout container. Set this higher than the content max-width.'),
       '#attributes' => [
         'class' => ['dxb-slider', 'box-max-width-range'],
         'data-dxb-slider' => TRUE,
@@ -89,7 +89,7 @@ function layout_theme_settings(array &$form, $theme) {
     '#min' => 480,
     '#max' => 4100,
     '#step' => 10,
-    '#description' => t('Max width of the website container. 480px - 4100px. Default is 1320px. With Side-Header enabled we typically use 980px.'),
+    '#description' => t('Maximum width of the main content container. Default is 1170px.'),
     '#attributes' => [
       'class' => ['dxb-slider', 'layout-max-width-range'],
       'data-dxb-slider' => TRUE,
@@ -98,12 +98,12 @@ function layout_theme_settings(array &$form, $theme) {
 
   $form['dxpr_theme_settings']['layout']['grid']['gutter_horizontal'] = [
     '#type' => 'range',
-    '#title' => t('Space between columns'),
+    '#title' => t('Column Spacing'),
     '#default_value' => ((theme_get_setting('gutter_horizontal') !== NULL)) ? theme_get_setting('gutter_horizontal') : 20,
     '#min' => 0,
     '#max' => 100,
     '#step' => 1,
-    '#description' => t('Default is 20px.'),
+    '#description' => t('Horizontal space between columns. Default is 20px.'),
     '#attributes' => [
       'class' => ['dxb-slider', 'gutter-horizontal-range'],
       'data-dxb-slider' => TRUE,
@@ -112,12 +112,12 @@ function layout_theme_settings(array &$form, $theme) {
 
   $form['dxpr_theme_settings']['layout']['grid']['gutter_vertical'] = [
     '#type' => 'range',
-    '#title' => t('Space between rows'),
+    '#title' => t('Row Spacing'),
     '#default_value' => ((theme_get_setting('gutter_vertical') !== NULL)) ? theme_get_setting('gutter_vertical') : 30,
     '#min' => 0,
     '#max' => 100,
     '#step' => 1,
-    '#description' => t('Default is 20px.'),
+    '#description' => t('Vertical space between rows. Default is 30px.'),
     '#attributes' => [
       'class' => ['dxb-slider', 'gutter-vertical-range'],
       'data-dxb-slider' => TRUE,
@@ -126,12 +126,12 @@ function layout_theme_settings(array &$form, $theme) {
 
   $form['dxpr_theme_settings']['layout']['grid']['gutter_container'] = [
     '#type' => 'range',
-    '#title' => t('Container Space'),
+    '#title' => t('Container Padding'),
     '#default_value' => ((theme_get_setting('gutter_container') !== NULL)) ? theme_get_setting('gutter_container') : 30,
     '#min' => 0,
     '#max' => 500,
     '#step' => 1,
-    '#description' => t('Default is 30px.'),
+    '#description' => t('Horizontal padding inside the container. Default is 30px.'),
     '#attributes' => [
       'class' => ['dxb-slider', 'gutter-container-range'],
       'data-dxb-slider' => TRUE,
@@ -148,27 +148,27 @@ function layout_theme_settings(array &$form, $theme) {
   // @see dxpr_theme_helper.module dxpr_theme_helper_settings_form_submit()
   $form['dxpr_theme_settings']['layout']['background']['background_image_path'] = [
     '#type' => 'textfield',
-    '#title' => t('Path to  background image'),
+    '#title' => t('Background Image Path'),
     '#default_value' => theme_get_setting('background_image_path'),
-    '#description' => t('The path to the file you would like to use as your page title background image. If you upload a file below it will automatically populate this text field'),
+    '#description' => t('Path to the background image file. This field is automatically populated when you upload an image below.'),
   ];
   $form['dxpr_theme_settings']['layout']['background']['background_image'] = [
     '#type' => 'media_library',
     '#allowed_bundles' => ['image'],
-    '#title' => t('Upload Background'),
+    '#title' => t('Upload Background Image'),
     '#default_value' => theme_get_setting('background_image'),
-    '#description' => t('The default page title image can also be changed per node, using the Header image field in the node form.'),
+    '#description' => t('Upload a default background image. You can override this per node using the Header Image field.'),
   ];
 
   $form['dxpr_theme_settings']['layout']['background']['background_image_style'] = [
     '#type' => 'radios',
-    '#title' => t('Background Style'),
+    '#title' => t('Background Size'),
     '#default_value' => ((theme_get_setting('background_image_style') !== NULL)) ? theme_get_setting('background_image_style') : 'cover',
     '#options' => [
-      'cover' => t('Cover'),
-      'contain' => t('Contain'),
-      'no_repeat' => t('No Repeat'),
-      'repeat' => t('Repeat'),
+      'cover' => t('Cover (fill area)'),
+      'contain' => t('Contain (fit inside)'),
+      'no_repeat' => t('Actual size'),
+      'repeat' => t('Tile'),
     ],
   ];
 
@@ -177,29 +177,29 @@ function layout_theme_settings(array &$form, $theme) {
     '#title' => t('Background Position'),
     '#default_value' => ((theme_get_setting('background_image_position') !== NULL)) ? theme_get_setting('background_image_position') : 'center_center',
     '#options' => [
-      'center_center' => t('Center Center'),
-      'left_top' => t('Left Top'),
-      'left_center' => t('Left Center'),
-      'left_bottom' => t('Left Bottom'),
-      'right_top' => t('Right Top'),
-      'right_center' => t('Right Center'),
-      'right_bottom' => t('Right Bottom'),
-      'center_bottom' => t('Center Bottom'),
+      'center_center' => t('Center'),
+      'left_top' => t('Top left'),
+      'left_center' => t('Center left'),
+      'left_bottom' => t('Bottom left'),
+      'right_top' => t('Top right'),
+      'right_center' => t('Center right'),
+      'right_bottom' => t('Bottom right'),
+      'center_bottom' => t('Bottom center'),
     ],
   ];
 
   $form['dxpr_theme_settings']['layout']['background']['background_image_attachment'] = [
     '#type' => 'radios',
-    '#title' => t('Background Mode'),
+    '#title' => t('Background Scroll Behavior'),
     '#default_value' => ((theme_get_setting('background_image_attachment') !== NULL)) ? theme_get_setting('background_image_attachment') : 'fixed',
     '#options' => [
-      'scroll' => t('Normal'),
-      'fixed' => t('Fixed (Parallax)'),
+      'scroll' => t('Scroll with page'),
+      'fixed' => t('Fixed (parallax effect)'),
     ],
   ];
 
   $form['dxpr_theme_settings']['layout']['mobile_layout'] = [
-    '#title' => t('Mobile view'),
+    '#title' => t('Mobile Layout'),
     '#type' => 'details',
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
@@ -207,12 +207,12 @@ function layout_theme_settings(array &$form, $theme) {
 
   $form['dxpr_theme_settings']['layout']['mobile_layout']['gutter_horizontal_mobile'] = [
     '#type' => 'range',
-    '#title' => t('Space between columns'),
+    '#title' => t('Column Spacing'),
     '#default_value' => ((theme_get_setting('gutter_horizontal_mobile') !== NULL)) ? theme_get_setting('gutter_horizontal_mobile') : 10,
     '#min' => 0,
     '#max' => 100,
     '#step' => 1,
-    '#description' => t('Width of the horizontal gutter in DXPR Theme mobile view (under 1200px). 0 - 100px. Default is 10.'),
+    '#description' => t('Horizontal space between columns on viewports under 1200px. Default is 10px.'),
     '#attributes' => [
       'class' => ['dxb-slider', 'gutter-horizontal-mobile-range'],
       'data-dxb-slider' => TRUE,
@@ -221,12 +221,12 @@ function layout_theme_settings(array &$form, $theme) {
 
   $form['dxpr_theme_settings']['layout']['mobile_layout']['gutter_vertical_mobile'] = [
     '#type' => 'range',
-    '#title' => t('Space between rows'),
+    '#title' => t('Row Spacing'),
     '#default_value' => ((theme_get_setting('gutter_vertical_mobile') !== NULL)) ? theme_get_setting('gutter_vertical_mobile') : 10,
     '#min' => 0,
     '#max' => 100,
     '#step' => 1,
-    '#description' => t('Width of the vertical gutter in DXPR Theme mobile view (under 1200px). 0 - 100px. Default is 10px.'),
+    '#description' => t('Vertical space between rows on viewports under 1200px. Default is 10px.'),
     '#attributes' => [
       'class' => ['dxb-slider', 'gutter-vertical-mobile-range'],
       'data-dxb-slider' => TRUE,
@@ -235,12 +235,12 @@ function layout_theme_settings(array &$form, $theme) {
 
   $form['dxpr_theme_settings']['layout']['mobile_layout']['gutter_container_mobile'] = [
     '#type' => 'range',
-    '#title' => t('Mobile Container space'),
+    '#title' => t('Container Padding'),
     '#default_value' => ((theme_get_setting('gutter_container_mobile') !== NULL)) ? theme_get_setting('gutter_container_mobile') : 20,
     '#min' => 0,
     '#max' => 500,
     '#step' => 1,
-    '#description' => t('Default is 20px.'),
+    '#description' => t('Horizontal padding inside the container on viewports under 1200px. Default is 20px.'),
     '#attributes' => [
       'class' => ['dxb-slider', 'gutter-container-mobile-range'],
       'data-dxb-slider' => TRUE,
@@ -257,13 +257,13 @@ function layout_theme_settings(array &$form, $theme) {
 
   $form['dxpr_theme_settings']['layout']['mobile_layout']['secondary_header']['secondary_header_hide'] = [
     '#type' => 'radios',
-    '#title' => t('Hide in small devices'),
+    '#title' => t('Hide on Small Devices'),
     '#default_value' => ((theme_get_setting('secondary_header_hide') !== NULL)) ? theme_get_setting('secondary_header_hide') : 'hidden_none',
     '#options' => [
       'hidden_none' => t('Never hide'),
-      'hidden_xs' => t('Extra small devices (<768px)'),
-      'hidden_sm' => t('Small devices (768px)'),
-      'hidden_md' => t('Medium devices (992px)'),
+      'hidden_xs' => t('Extra small devices (below 768px)'),
+      'hidden_sm' => t('Small devices (below 992px)'),
+      'hidden_md' => t('Medium devices (below 1200px)'),
     ],
   ];
 
@@ -277,8 +277,8 @@ function layout_theme_settings(array &$form, $theme) {
   $form['dxpr_theme_settings']['layout']['granular_boxed']['full_width_containers'] = [
     '#type' => 'checkboxes',
     '#multiple' => TRUE,
-    '#title' => t('Full width regions'),
-    '#description' => t('Full width content regions have 2 use cases: creating blocks that span across the whole browser and creating layouts with full screen backgrounds within your content. If you want all content to be full width, don\'t use these settings but instead set the "Layout Max-width" setting to the maximum value.'),
+    '#title' => t('Full Width Regions'),
+    '#description' => t('Select regions that should span the full browser width. Useful for full-width blocks or full-screen backgrounds.'),
     '#default_value' => ((theme_get_setting('full_width_containers') !== NULL)) ? theme_get_setting('full_width_containers') : [],
     '#options' => [
       'cnt_secondary_header' => t('Secondary Header'),
@@ -302,8 +302,8 @@ function layout_theme_settings(array &$form, $theme) {
   }
   $form['dxpr_theme_settings']['layout']['granular_boxed']['full_width_content_types'] = [
     '#type' => 'checkboxes',
-    '#title' => t('Full width content types'),
-    '#description' => t('If you want to create Drag and Drop pages with full-width sections you need this setting. This only works if the pages have no sidebar blocks. When you enable sidebar blocks alongside your full-width content pages they will simply squish into fixed containers to make room for the sidebar.'),
+    '#title' => t('Full Width Content Types'),
+    '#description' => t('Enable full-width sections for these content types. Only works on pages without sidebars.'),
     '#default_value' => ((theme_get_setting('full_width_content_types') !== NULL)) ? theme_get_setting('full_width_content_types') : $default_options,
     '#options' => _dxpr_theme_node_types_options(),
   ];
@@ -328,8 +328,8 @@ function layout_theme_settings(array &$form, $theme) {
   $form['dxpr_theme_settings']['layout']['hide_regions']['hidden_regions'] = [
     '#type' => 'checkboxes',
     '#multiple' => TRUE,
-    '#title' => t('Hide Regions'),
-    '#description' => t('Globally disables regions.'),
+    '#title' => t('Hidden Regions'),
+    '#description' => t('Selected regions will be hidden site-wide.'),
     '#default_value' => ((theme_get_setting('hidden_regions') !== NULL)) ? theme_get_setting('hidden_regions') : [],
     '#options' => [
       'navigation' => t('Navigation (branding)'),

--- a/features/sooper-page-title/page_title-theme-settings.inc
+++ b/features/sooper-page-title/page_title-theme-settings.inc
@@ -45,9 +45,8 @@ function page_title_theme_settings(array &$form, $theme) {
 
   $form['dxpr_theme_settings']['page_title']['page_title_breadcrumbs_separator'] = [
     '#type' => 'textfield',
-    '#title' => t('Breadcrumbs separator'),
+    '#title' => t('Breadcrumbs Separator'),
     '#default_value' => (theme_get_setting('page_title_breadcrumbs_separator')) ? theme_get_setting('page_title_breadcrumbs_separator') : '/',
-    '#description' => t('Add custom breadcrumbs separator symbol. Leave empty for default separator.'),
     '#states' => [
       'visible' => [
         ':input[name="page_title_breadcrumbs"]' => ['checked' => TRUE],
@@ -70,7 +69,6 @@ function page_title_theme_settings(array &$form, $theme) {
       'center' => t('Center'),
       'right' => t('Right'),
     ],
-    '#description' => t('Choose position of Page Title within page title header.'),
   ];
 
   $form['dxpr_theme_settings']['page_title']['title_type'] = [
@@ -91,7 +89,7 @@ function page_title_theme_settings(array &$form, $theme) {
     '#min' => 50,
     '#max' => 500,
     '#step' => 5,
-    '#description' => t('height of the header. 50px - 500px. Default is 120px.'),
+    '#description' => t('Height of the page title area.'),
     '#attributes' => [
       'class' => ['dxb-slider', 'page-title-height-range'],
       'data-dxb-slider' => TRUE,
@@ -114,7 +112,6 @@ function page_title_theme_settings(array &$form, $theme) {
       'fade-in-up-dxpr' => t('Fade in up'),
     ],
     '#prefix' => '<br class="clear-both"><br class="clear-both">',
-    '#description' => t('Choose an animation.'),
   ];
 
   $form['dxpr_theme_settings']['page_title']['background'] = [
@@ -127,16 +124,16 @@ function page_title_theme_settings(array &$form, $theme) {
   // @see dxpr_theme_helper.module dxpr_theme_helper_settings_form_submit()
   $form['dxpr_theme_settings']['page_title']['background']['page_title_image_path'] = [
     '#type' => 'textfield',
-    '#title' => t('Path to background image'),
+    '#title' => t('Background Image Path'),
     '#default_value' => theme_get_setting('page_title_image_path'),
-    '#description' => t('The path to the file you would like to use as your page title background image. If you upload a file below it will automatically populate this text field'),
+    '#description' => t('Automatically populated when you upload an image below.'),
   ];
   $form['dxpr_theme_settings']['page_title']['background']['page_title_image'] = [
     '#type' => 'media_library',
     '#allowed_bundles' => ['image'],
-    '#title' => t('Upload Background'),
+    '#title' => t('Upload Background Image'),
     '#default_value' => theme_get_setting('page_title_image'),
-    '#description' => t('The default page title image can also be changed per node, using the Header image field in the node form.'),
+    '#description' => t('Override per node using the Header Image field.'),
   ];
 
   $form['dxpr_theme_settings']['page_title']['background']['page_title_image_opacity'] = [
@@ -146,7 +143,7 @@ function page_title_theme_settings(array &$form, $theme) {
     '#min' => 0,
     '#max' => 1,
     '#step' => 0.01,
-    '#description' => t('Use this to blend the background image with a color. 0 is fully transparent and 1 is fully opaque.'),
+    '#description' => t('Blend the background image with the background color. 0 = transparent, 1 = opaque.'),
     '#attributes' => [
       'class' => ['dxb-slider', 'page-title-image-opacity-range'],
       'data-dxb-slider' => TRUE,
@@ -155,23 +152,23 @@ function page_title_theme_settings(array &$form, $theme) {
 
   $form['dxpr_theme_settings']['page_title']['background']['page_title_image_style'] = [
     '#type' => 'radios',
-    '#title' => t('Background Style'),
+    '#title' => t('Background Size'),
     '#default_value' => ((theme_get_setting('page_title_image_style') !== NULL)) ? theme_get_setting('page_title_image_style') : 'cover',
     '#options' => [
-      'cover' => t('Cover'),
-      'contain' => t('Contain'),
-      'no_repeat' => t('No Repeat'),
-      'repeat' => t('Repeat'),
+      'cover' => t('Cover (fill area)'),
+      'contain' => t('Contain (fit inside)'),
+      'no_repeat' => t('Actual size'),
+      'repeat' => t('Tile'),
     ],
   ];
 
   $form['dxpr_theme_settings']['page_title']['background']['page_title_image_mode'] = [
     '#type' => 'radios',
-    '#title' => t('Background Mode'),
+    '#title' => t('Background Scroll Behavior'),
     '#default_value' => ((theme_get_setting('page_title_image_mode') !== NULL)) ? theme_get_setting('page_title_image_mode') : 'normal',
     '#options' => [
-      'normal' => t('Normal'),
-      'fixed' => t('Fixed (Parallax)'),
+      'normal' => t('Scroll with page'),
+      'fixed' => t('Fixed (parallax effect)'),
     ],
   ];
 
@@ -180,14 +177,14 @@ function page_title_theme_settings(array &$form, $theme) {
     '#title' => t('Background Position'),
     '#default_value' => ((theme_get_setting('page_title_image_position') !== NULL)) ? theme_get_setting('page_title_image_position') : 'center_center',
     '#options' => [
-      'center_center' => t('Center Center'),
-      'left_top' => t('Left Top'),
-      'left_center' => t('Left Center'),
-      'left_bottom' => t('Left Bottom'),
-      'right_top' => t('Right Top'),
-      'right_center' => t('Right Center'),
-      'right_bottom' => t('Right Bottom'),
-      'center_bottom' => t('Center Bottom'),
+      'center_center' => t('Center'),
+      'left_top' => t('Top left'),
+      'left_center' => t('Center left'),
+      'left_bottom' => t('Bottom left'),
+      'right_top' => t('Top right'),
+      'right_center' => t('Center right'),
+      'right_bottom' => t('Bottom right'),
+      'center_bottom' => t('Bottom center'),
     ],
   ];
 }

--- a/features/sooper-typography/typography-theme-settings.inc
+++ b/features/sooper-typography/typography-theme-settings.inc
@@ -76,7 +76,8 @@ function typography_theme_settings(array &$form, $theme) {
 
   $form['dxpr_theme_settings']['typography']['scale_factor'] = [
     '#type' => 'range',
-    '#title' => t('Typography Scale Factor') . ' <small>' . t('(This overrides advanced type controls)') . '</small>',
+    '#title' => t('Typography Scale Factor'),
+    '#description' => t('This overrides advanced type controls.'),
     '#default_value' => ((theme_get_setting('scale_factor') !== NULL)) ? theme_get_setting('scale_factor') : 1,
     '#min' => 1,
     '#max' => 2,
@@ -89,7 +90,7 @@ function typography_theme_settings(array &$form, $theme) {
 
   $form['dxpr_theme_settings']['typography']['advanced_type'] = [
     '#title' => t('Advanced Type Controls'),
-    '#description' => t('Changing the main controls above will override these values.'),
+    '#description' => t('The Scale Factor control above will recalculate these font sizes when changed.'),
     '#type' => 'details',
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,

--- a/features/sooper-typography/typography-theme-settings.inc
+++ b/features/sooper-typography/typography-theme-settings.inc
@@ -89,7 +89,7 @@ function typography_theme_settings(array &$form, $theme) {
 
   $form['dxpr_theme_settings']['typography']['advanced_type'] = [
     '#title' => t('Advanced Type Controls'),
-    '#description' => t('If you change the main contorls above these advanced controls are automatically generated and need might re-adjustment.'),
+    '#description' => t('Changing the main controls above will override these values.'),
     '#type' => 'details',
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,

--- a/features/sooper-typography/typography-theme-settings.inc
+++ b/features/sooper-typography/typography-theme-settings.inc
@@ -323,7 +323,8 @@ function typography_theme_settings(array &$form, $theme) {
 
   $form['dxpr_theme_settings']['typography']['divider']['divider_length'] = [
     '#type' => 'range',
-    '#title' => t('Divider Length') . ' <small>' . t('(0 = full width)') . '</small>',
+    '#title' => t('Divider Length'),
+    '#description' => t('Set to 0 for full width.'),
     '#default_value' => ((theme_get_setting('divider_length') !== NULL)) ? theme_get_setting('divider_length') : 100,
     '#min' => 0,
     '#max' => 500,


### PR DESCRIPTION
## Linked issues

- #690

## Solution

Apply consistent formatting and improve clarity across all theme settings forms:

- **Title Case consistency**: All form labels now use Title Case (e.g., "Base font" → "Base Font")
- **Concise descriptions**: Removed verbose or redundant help text that doesn't add value
- **Accurate information**: Removed incorrect default values from descriptions (the UI already shows defaults)
- **Self-descriptive options**: Radio/select options now include context in the label (e.g., "Cover (fill area)" instead of just "Cover")
- **Bug fixes**: Fixed typo "contorls" → "controls" in typography settings
- **Standardization**: Opacity descriptions now consistently use "0 = transparent, 1 = opaque"

### Files changed
- `features/sooper-block-design/block-design-theme-settings.inc`
- `features/sooper-colors/colors-theme-settings.inc`
- `features/sooper-custom-css/custom-css-theme-settings.inc`
- `features/sooper-fonts/fonts-theme-settings.inc`
- `features/sooper-header/header-theme-settings.inc`
- `features/sooper-layout/layout-theme-settings.inc`
- `features/sooper-page-title/page_title-theme-settings.inc`
- `features/sooper-typography/typography-theme-settings.inc`

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.