### PR TITLE
Add Building Artifacts section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,9 @@ Issues or PRs that do not use templates will be closed and asked to resubmit.
    create artifacts on the fly.
 7. If the issue defines a "Scope of affected files" do not include changes to
    files not in this list unless absolutely necessary. When you do this you must
-   explain why. 
+   explain why.
+8. Do NOT run `npx`, `npm run`, or `grunt` directly to build artifacts. Use the
+   Docker watch process or Docker build commands from the README instead. 
 
 ### Code ownership
 


### PR DESCRIPTION
## Linked issues

- #744

## Solution

Added a new "Building Artifacts" section to CONTRIBUTING.md that:

1. Explicitly forbids running `npx`, `npm run`, or `grunt` commands directly
2. Explains why: inconsistent output due to local environment differences
3. Documents the correct approach: use Docker watch process during development or Docker commands for manual builds

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [x] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.