### PR TITLE
Add AI module installation hint when AI features unavailable

### DIFF
--- a/features/sooper-colors/colors-theme-settings.inc
+++ b/features/sooper-colors/colors-theme-settings.inc
@@ -104,6 +104,19 @@ function colors_theme_settings(array &$form, $theme) {
       ],
     ];
   }
+  else {
+    // Show promotional message when AI module is not available.
+    $form['dxpr_theme_settings']['colors']['wrapper']['ai_palette_promo'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => t('Install the <a href="@url">AI module</a> to generate color palettes with AI.', [
+        '@url' => 'https://drupal.org/project/ai',
+      ]),
+      '#attributes' => [
+        'class' => ['text-muted', 'fst-italic'],
+      ],
+    ];
+  }
 
   $form['dxpr_theme_settings']['colors']['wrapper']['color_palette'] = [
     '#type' => 'html_tag',

--- a/features/sooper-fonts/fonts-theme-settings.inc
+++ b/features/sooper-fonts/fonts-theme-settings.inc
@@ -77,6 +77,20 @@ function fonts_theme_settings(array &$form, $theme) {
       ],
     ];
   }
+  else {
+    // Show promotional message when AI module is not available.
+    $form['dxpr_theme_settings']['fonts']['ai_fonts_promo'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => t('Install the <a href="@url">AI module</a> to generate font pairings with AI.', [
+        '@url' => 'https://drupal.org/project/ai',
+      ]),
+      '#attributes' => [
+        'class' => ['text-muted', 'fst-italic'],
+      ],
+      '#weight' => -10,
+    ];
+  }
 
   // Regular Fonts Settings.
   $form['dxpr_theme_settings']['fonts']['body_font_face'] = [


### PR DESCRIPTION
## Linked issues

- #750

## Solution

When the AI module is not installed, display a helpful hint in the Colors and Fonts theme settings sections. The message is styled with muted text and italics to be unobtrusive while still guiding users toward the AI features.

- Colors section: "Install the AI module to generate color palettes with AI."
- Fonts section: "Install the AI module to generate font pairings with AI."

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.