### PR TITLE
Fix Home active state on front page (closes #768)

### DIFF
--- a/dxpr_theme.theme
+++ b/dxpr_theme.theme
@@ -291,7 +291,8 @@ function dxpr_theme_preprocess_menu(&$variables) {
   }
 
   $current_path = \Drupal::service('path.current')->getPath();
-  dxpr_theme_menu_set_active_trail($variables['items'], $current_path);
+  $is_front = \Drupal::service('path.matcher')->isFrontPage();
+  dxpr_theme_menu_set_active_trail($variables['items'], $current_path, $is_front);
 
   // Ensure menu is cached per URL to prevent wrong active states.
   $variables['#cache']['contexts'][] = 'url.path';
@@ -304,13 +305,14 @@ function dxpr_theme_preprocess_menu(&$variables) {
  *   Menu items array (passed by reference).
  * @param string $current_path
  *   Current page path (e.g., "/test-view").
+ * @param bool $is_front
+ *   Whether the current page is the front page.
  *
  * @return bool
  *   TRUE if any item in this level or below is active.
  */
-function dxpr_theme_menu_set_active_trail(array &$items, $current_path) {
+function dxpr_theme_menu_set_active_trail(array &$items, $current_path, $is_front) {
   $has_active = FALSE;
-  $is_front = \Drupal::service('path.matcher')->isFrontPage();
 
   foreach ($items as &$item) {
     if (empty($item['url'])) {
@@ -324,7 +326,7 @@ function dxpr_theme_menu_set_active_trail(array &$items, $current_path) {
       $item_path = $item['url'] instanceof
       Url ? $item['url']->toString()
         : (string) $item['url'];
-      if ($item_path === $current_path || ($is_front && ($item_path === '/' || $item_path === ''))) {
+      if ($item_path === $current_path || ($is_front && $item_path === '/')) {
         $item['in_active_trail'] = TRUE;
         $item['is_active'] = TRUE;
         $is_active = TRUE;
@@ -335,7 +337,7 @@ function dxpr_theme_menu_set_active_trail(array &$items, $current_path) {
     }
 
     if (!empty($item['below'])) {
-      $child_active = dxpr_theme_menu_set_active_trail($item['below'], $current_path);
+      $child_active = dxpr_theme_menu_set_active_trail($item['below'], $current_path, $is_front);
       if ($child_active && empty($item['in_active_trail'])) {
         $item['in_active_trail'] = TRUE;
       }

--- a/dxpr_theme.theme
+++ b/dxpr_theme.theme
@@ -310,6 +310,7 @@ function dxpr_theme_preprocess_menu(&$variables) {
  */
 function dxpr_theme_menu_set_active_trail(array &$items, $current_path) {
   $has_active = FALSE;
+  $is_front = \Drupal::service('path.matcher')->isFrontPage();
 
   foreach ($items as &$item) {
     if (empty($item['url'])) {
@@ -323,7 +324,7 @@ function dxpr_theme_menu_set_active_trail(array &$items, $current_path) {
       $item_path = $item['url'] instanceof
       Url ? $item['url']->toString()
         : (string) $item['url'];
-      if ($item_path === $current_path) {
+      if ($item_path === $current_path || ($is_front && ($item_path === '/' || $item_path === ''))) {
         $item['in_active_trail'] = TRUE;
         $item['is_active'] = TRUE;
         $is_active = TRUE;


### PR DESCRIPTION
## Linked issues

- #768
- Drupal.org: https://www.drupal.org/project/dxpr_theme/issues/3567597

## Solution

Fixes Home menu item not receiving active state on front page in Drupal 10.
Problem: When the front page is set to a node path (e.g., /node/1), the Home menu item (pointing to /) was not marked as active because the path comparison (/node/1 vs /) failed.
Fix: Added a front page check in the menu active trail detection logic. When on the front page, menu items pointing to / are now correctly marked as active, matching the behavior of other menu items.
This ensures consistent navigation styling across all menu items, including Home, when users are on the homepage.
Testing: Verified on Drupal 10.6.2. Works correctly in Drupal 11 (no changes needed there).

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
