### PR TITLE
Add ADR for build pipeline consolidation

### DIFF
--- a/docs/adr/001-consolidate-build-pipeline.md
+++ b/docs/adr/001-consolidate-build-pipeline.md
@@ -1,0 +1,50 @@
+# ADR 001: Consolidate Build Pipeline
+
+## Status
+
+Proposed
+
+## Context
+
+The theme currently uses two separate build systems:
+
+1. **Grunt** (`Gruntfile.js`) — orchestrates SCSS compilation (`grunt-sass`), CSS post-processing (`autoprefixer`, `postcss-pxtorem`), and JS minification (`terser`)
+2. **Webpack** (`webpack.config.js`) — handles JS bundling and Babel transpilation
+
+This creates maintenance overhead (two configs, two sets of plugins) and increases contributor onboarding friction.
+
+## Decision
+
+Consolidate into a single Webpack-based pipeline that handles:
+
+- SCSS compilation via `sass-loader`
+- CSS post-processing via `postcss-loader` (autoprefixer, pxtorem)
+- JS bundling and transpilation via `babel-loader` (already in use)
+- JS minification via `terser-webpack-plugin`
+
+## Consequences
+
+### Positive
+
+- Single build config (`webpack.config.js`)
+- Remove `Gruntfile.js` and Grunt-specific dependencies
+- Enable tree-shaking for JS bundles
+- Consistent source maps across CSS and JS
+- Fewer dev dependencies to maintain
+
+### Negative
+
+- Migration effort required
+- Docker build commands (`docker-compose.yml`) need updating
+- Must verify output compatibility with Drupal library definitions
+
+### Risks
+
+- CSS output must remain identical to avoid visual regressions
+- The `postcss-pxtorem` plugin behavior must be preserved
+- Drupal.org packaging requirements must still be met (artifacts committed to repo)
+
+## Alternatives Considered
+
+- **Vite**: Faster dev builds but less Drupal ecosystem precedent
+- **Keep Grunt, remove Webpack**: Grunt is effectively unmaintained


### PR DESCRIPTION
## Linked issues

- #775

## Solution

Add an Architecture Decision Record (ADR) proposing the consolidation of the dual Grunt + Webpack build pipeline into a single Webpack-based pipeline. This PR is for team discussion and decision-making before implementation begins.

The ADR documents:
- Current dual-system architecture and its problems
- Proposed Webpack-only approach
- Expected benefits (single config, tree-shaking, fewer dependencies)
- Risks and migration concerns
- Alternatives considered (Vite, keeping Grunt)

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [x] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.