### PR TITLE
Drale1/8.x/fix php 8 type error in block design regions or hidden regions in dxpr theme.theme

### DIFF
--- a/dxpr_theme.theme
+++ b/dxpr_theme.theme
@@ -200,8 +200,9 @@ function dxpr_theme_preprocess_page(&$variables) {
   $variables['navbar_attributes'] = new Attribute($variables['navbar_attributes']);
 
   $hide_regions = $local_hide = [];
-  if (theme_get_setting('hidden_regions') && !empty(array_keys(array_filter(theme_get_setting('hidden_regions'))))) {
-    $hide_regions = array_keys(array_filter(theme_get_setting('hidden_regions')));
+  $hidden_regions = theme_get_setting('hidden_regions');
+  if (is_array($hidden_regions) && !empty(array_keys(array_filter($hidden_regions)))) {
+    $hide_regions = array_keys(array_filter($hidden_regions));
   }
   if (!empty($variables['node'])
     && $variables['node'] instanceof NodeInterface
@@ -436,7 +437,8 @@ function dxpr_theme_preprocess_region(&$variables) {
   }
 
   // Apply class to block design regions.
-  if ($block_design_regions = array_keys(array_filter(theme_get_setting('block_design_regions')))) {
+  $block_design_regions_setting = theme_get_setting('block_design_regions');
+  if (is_array($block_design_regions_setting) && ($block_design_regions = array_keys(array_filter($block_design_regions_setting)))) {
     if (in_array($variables['region'], $block_design_regions)) {
       $variables['attributes']['class'][] = 'region-block-design';
     }


### PR DESCRIPTION
## Linked issues

- #781

Fix is related to the Drupal.org issue https://www.drupal.org/project/dxpr_theme/issues/3570233

## Solution

This PR adds simple `is_array()` guards around `theme_get_setting('hidden_regions')` and `theme_get_setting('block_design_regions')` before passing their values into `array_filter()` in `dxpr_theme.theme`.

On PHP 8+, `theme_get_setting()` can return `null` for these settings on some configurations. Passing `null` directly into `array_filter()` causes a `TypeError`. With the guards in place, the theme safely skips applying the related logic when the settings are not defined, and pages render without PHP fatals.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
