### PR TITLE
Fix native font weight overridden by bold checkbox

### DIFF
--- a/features/sooper-fonts/fonts-theme-settings-css.inc
+++ b/features/sooper-fonts/fonts-theme-settings-css.inc
@@ -41,7 +41,7 @@ function fonts_theme_settings_css(string $theme, &$css, array $palette) {
       $css .= $selector . " {\n";
       $css .= _dxpr_theme_settings_add_css($font_key, 'font-family');
       $css .= "  font-style: $style;\n";
-      $css .= "  font-weight: $weight;\n";
+      $css .= "  font-weight: $weight !important;\n";
       $css .= "}\n\n";
     }
   }


### PR DESCRIPTION
## Linked issues

- #796

## Solution

Added `!important` to the `font-weight` declaration in `fonts-theme-settings-css.inc` so the native font weight from font selection (e.g. 900) is no longer overridden by the `headings_bold` checkbox CSS. Since `themesettings-dxpr_theme.css` loads after the theme CSS, source order gives this rule precedence.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.