### PR TITLE
Update headings font selector: drop tp-caption, add Bootstrap 5 classes

### DIFF
--- a/config/install/dxpr_theme.settings.yml
+++ b/config/install/dxpr_theme.settings.yml
@@ -62,7 +62,7 @@ h4_mobile_font_size: '24'
 body_font_face: SF_Segoe_Roboto
 body_font_face_selector: body
 headings_font_face: SF_Segoe_Roboto
-headings_font_face_selector: 'h1,h2,h3,h4,h5,h6,label,.field--label,.page-title, .html .tp-caption'
+headings_font_face_selector: 'h1,.h1,h2,.h2,h3,.h3,h4,.h4,h5,.h5,h6,.h6,.display-1,.display-2,.display-3,.display-4,.display-5,.display-6,label,.field--label,.page-title'
 nav_font_face: SF_Segoe_Roboto
 nav_font_face_selector: 'nav,nav ul li,nav a'
 sitename_font_face: SF_Segoe_Roboto

--- a/dxpr_theme_STARTERKIT/config/install/dxpr_theme_STARTERKIT.settings.yml
+++ b/dxpr_theme_STARTERKIT/config/install/dxpr_theme_STARTERKIT.settings.yml
@@ -62,7 +62,7 @@ h4_mobile_font_size: '24'
 body_font_face: '0Source+Sans+Pro:'
 body_font_face_selector: body
 headings_font_face: '0Source+Sans+Pro:300'
-headings_font_face_selector: 'h1,h2,h3,h4,h5,h6,label,.field--label,.page-title, .html .tp-caption'
+headings_font_face_selector: 'h1,.h1,h2,.h2,h3,.h3,h4,.h4,h5,.h5,h6,.h6,.display-1,.display-2,.display-3,.display-4,.display-5,.display-6,label,.field--label,.page-title'
 nav_font_face: '0Source+Sans+Pro:'
 nav_font_face_selector: '.dxpr-theme-header .nav'
 sitename_font_face: '0Source+Sans+Pro:300'

--- a/features/sooper-fonts/fonts-theme-settings.inc
+++ b/features/sooper-fonts/fonts-theme-settings.inc
@@ -117,7 +117,7 @@ function fonts_theme_settings(array &$form, $theme) {
   $form['dxpr_theme_settings']['fonts']['headings_font_face_selector'] = [
     '#type' => 'textfield',
     '#title' => t('CSS Selector'),
-    '#default_value' => ((theme_get_setting('headings_font_face_selector') !== NULL)) ? theme_get_setting('headings_font_face_selector') : 'h1,h2,h3,h4,h5,h6,label,.field--label,.page-title, .html .tp-caption',
+    '#default_value' => ((theme_get_setting('headings_font_face_selector') !== NULL)) ? theme_get_setting('headings_font_face_selector') : 'h1,.h1,h2,.h2,h3,.h3,h4,.h4,h5,.h5,h6,.h6,.display-1,.display-2,.display-3,.display-4,.display-5,.display-6,label,.field--label,.page-title',
   ];
 
   $form['dxpr_theme_settings']['fonts']['nav_font_face'] = [


### PR DESCRIPTION
## Linked issues

- #798

## Solution

Updated the default `headings_font_face_selector` to remove the obsolete Revolution Slider `.html .tp-caption` selector and add Bootstrap 5 heading classes (`.h1`–`.h6`, `.display-1`–`.display-6`).

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.