### PR TITLE
ci: add settings schema freshness check to PR review workflow

### DIFF
--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -50,6 +50,29 @@ jobs:
           name: stylelint-report
           path: out/stylelint-report.html
 
+  schema-check:
+    runs-on: ubicloud-standard-4
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - name: Generate settings schema
+      run: node scripts/generate-settings-schema.js
+
+    - name: Verify schema is up-to-date
+      run: |
+        if ! git diff -I '"generated":' --quiet data/settings-schema.json; then
+          echo "ERROR: data/settings-schema.json is out of date."
+          echo "Run 'node scripts/generate-settings-schema.js' and commit the result."
+          git diff -I '"generated":' data/settings-schema.json
+          exit 1
+        fi
+
   # review by commenting on code (experimental)
   # eslint-review:
   #   runs-on: ubicloud-standard-4


### PR DESCRIPTION
## Summary

Adds a `schema-check` job to the PR review workflow that verifies `data/settings-schema.json` is up-to-date with the PHP form definitions.

Follow-up to #803 which introduced the auto-generated schema but didn't wire the freshness check into CI.

### How it works

1. Runs `node scripts/generate-settings-schema.js` to regenerate the schema
2. Compares with the committed version using `git diff -I '"generated":'` (ignoring the timestamp line)
3. Fails if the schema is stale, showing the diff

This ensures developers who change `features/*-theme-settings.inc` also regenerate and commit the schema.

## Test plan

- [ ] Change a `#ai_description` in any inc file, commit without regenerating schema → CI should fail
- [ ] Regenerate and commit → CI should pass