### PR TITLE
Remove em dashes from theme settings and exclude fonts from lint

### DIFF
--- a/.github/workflows/emdash-lint.yml
+++ b/.github/workflows/emdash-lint.yml
@@ -27,6 +27,7 @@ jobs:
           --exclude-dir='node_modules' \
           --exclude-dir='vendor' \
           --exclude-dir='.claude' \
+          --exclude-dir='fonts' \
           --exclude='.gitlab-ci.yml' \
           --exclude='emdash-lint.yml' \
           . ; then
@@ -44,6 +45,7 @@ jobs:
           --exclude-dir='node_modules' \
           --exclude-dir='vendor' \
           --exclude-dir='.claude' \
+          --exclude-dir='fonts' \
           . ; then
           FOUND=1
         fi

--- a/data/settings-schema.json
+++ b/data/settings-schema.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "description": "DXPR Theme settings schema. Auto-generated from features/*-theme-settings.inc files.",
-    "generated": "2026-04-06T09:11:27.801Z",
+    "generated": "2026-05-18T09:43:18.076Z",
     "sections": [
       "block-design",
       "colors",
@@ -17,7 +17,7 @@
       "type": "Value type: boolean, range, radios, select, textfield, textarea, checkboxes, font, color, theme_color, media, path, serialized_palette",
       "title": "Short human label (shown in GUI)",
       "description": "Terse GUI description",
-      "ai_description": "Design-oriented guidance for AI agents — visual effects, value ranges for different styles, relationships",
+      "ai_description": "Design-oriented guidance for AI agents: visual effects, value ranges for different styles, relationships",
       "options": "Valid values for radios/select/checkboxes (object or _dynamic)",
       "min": "Minimum value for range type",
       "max": "Maximum value for range type",
@@ -383,7 +383,7 @@
     "section": "header",
     "type": "radios",
     "title": "Layout",
-    "ai_description": "Visual arrangement of logo and navigation. 0=logo left, menu right (standard business/corporate — most versatile). centered=logo stacked above centered menu (boutique, restaurant, elegant). centered_inline=logo centered between split menu halves (fashion, luxury). logo_left_menu_left=both left-aligned (editorial, news). logo_center_menu_left=logo centered, menu left (portfolio). logo_center_menu_right=logo centered, menu right (portfolio variant). logo_right_menu_left=logo right, menu left (RTL-friendly, unconventional).",
+    "ai_description": "Visual arrangement of logo and navigation. 0=logo left, menu right (standard business/corporate, most versatile). centered=logo stacked above centered menu (boutique, restaurant, elegant). centered_inline=logo centered between split menu halves (fashion, luxury). logo_left_menu_left=both left-aligned (editorial, news). logo_center_menu_left=logo centered, menu left (portfolio). logo_center_menu_right=logo centered, menu right (portfolio variant). logo_right_menu_left=logo right, menu left (RTL-friendly, unconventional).",
     "options": {
       "0": "Normal (Logo left, Menu Right)",
       "centered": "Centered (stacked)",
@@ -400,7 +400,7 @@
     "type": "radios",
     "title": "Header Style",
     "description": "Overlay mode places the header over page content, allowing transparent backgrounds.",
-    "ai_description": "normal=standard header with its own background band above page content. overlay=header floats transparently over page content (hero images show through). Overlay is dramatic for landing pages with hero images — pair with reduced header_top_bg_opacity for glass effect.",
+    "ai_description": "normal=standard header with its own background band above page content. overlay=header floats transparently over page content (hero images show through). Overlay is dramatic for landing pages with hero images; pair with reduced header_top_bg_opacity for glass effect.",
     "options": {
       "normal": "Normal",
       "overlay": "Overlay"
@@ -453,7 +453,7 @@
     "type": "boolean",
     "title": "Sticky Header",
     "description": "Header appears after scrolling past a specified offset.",
-    "ai_description": "Requires header_top_fixed=true. When enabled, header shrinks/transforms after scrolling past header_top_height_sticky_offset. Creates a compact navigation that appears on scroll — common modern UX pattern. Configure the smaller size with header_top_height_scroll.",
+    "ai_description": "Requires header_top_fixed=true. When enabled, header shrinks/transforms after scrolling past header_top_height_sticky_offset. Creates a compact navigation that appears on scroll, a common modern UX pattern. Configure the smaller size with header_top_height_scroll.",
     "default": false
   },
   "second_header_sticky": {
@@ -762,7 +762,7 @@
     "section": "header",
     "type": "radios",
     "title": "Font Style",
-    "ai_description": "Font treatment for main menu links. (empty)=normal text. uppercase=ALL CAPS (strong, authoritative — corporate/tech). bold=heavier weight (prominent nav). lead=larger text (statement navigation). Uppercase + border hover creates a sophisticated nav pattern.",
+    "ai_description": "Font treatment for main menu links. (empty)=normal text. uppercase=ALL CAPS (strong, authoritative, suits corporate/tech). bold=heavier weight (prominent nav). lead=larger text (statement navigation). Uppercase + border hover creates a sophisticated nav pattern.",
     "options": {
       "": "Normal",
       "uppercase": "Uppercase",
@@ -787,7 +787,7 @@
     "section": "header",
     "type": "radios",
     "title": "Hover Style",
-    "ai_description": "Visual feedback style when hovering over menu items. opacity=subtle fade (minimal, modern). background=colored fill behind item (corporate, clear). text=only text color changes (subtle). border=underline/overline effect (modern, editorial). Border hover is most popular in contemporary web design — configure with menu_border_* settings.",
+    "ai_description": "Visual feedback style when hovering over menu items. opacity=subtle fade (minimal, modern). background=colored fill behind item (corporate, clear). text=only text color changes (subtle). border=underline/overline effect (modern, editorial). Border hover is most popular in contemporary web design; configure with menu_border_* settings.",
     "options": {
       "opacity": "Opacity",
       "background": "Colored Background",
@@ -903,7 +903,7 @@
     "type": "boolean",
     "title": "Boxed Layout",
     "description": "When enabled, all container backgrounds are constrained to a centered column instead of spanning full width.",
-    "ai_description": "Controls whether page backgrounds span full viewport or are contained in a centered column. 0 (off)=full-bleed backgrounds spanning entire browser width — modern, immersive, preferred for contemporary SaaS/portfolio/agency sites. 1 (on)=backgrounds constrained to centered box with visible page margins — traditional corporate/blog feel. Most modern designs use 0.",
+    "ai_description": "Controls whether page backgrounds span full viewport or are contained in a centered column. 0 (off)=full-bleed backgrounds spanning entire browser width, modern and immersive, preferred for contemporary SaaS/portfolio/agency sites. 1 (on)=backgrounds constrained to centered box with visible page margins, traditional corporate/blog feel. Most modern designs use 0.",
     "default": 1
   },
   "sticky_footer": {
@@ -975,7 +975,7 @@
     "type": "range",
     "title": "Container Padding",
     "description": "Horizontal padding inside the container. Default is 30px.",
-    "ai_description": "Horizontal padding inside the main container — the breathing room between content and viewport edge. 15-20px=compact. 30px=standard. 50+px=generous whitespace for luxury/editorial feel.",
+    "ai_description": "Horizontal padding inside the main container, i.e. the breathing room between content and viewport edge. 15-20px=compact. 30px=standard. 50+px=generous whitespace for luxury/editorial feel.",
     "min": 0,
     "max": 500,
     "step": 1,
@@ -1116,7 +1116,7 @@
     "type": "checkboxes",
     "title": "Hidden Regions",
     "description": "Selected regions will be hidden site-wide.",
-    "ai_description": "Permanently hide theme regions site-wide. Useful for simplifying layouts — e.g., hide sidebar_first and sidebar_second for a single-column design, hide page_title for a minimal look, hide secondary_header if not using a top bar.",
+    "ai_description": "Permanently hide theme regions site-wide. Useful for simplifying layouts, e.g. hide sidebar_first and sidebar_second for a single-column design, hide page_title for a minimal look, hide secondary_header if not using a top bar.",
     "options": {
       "navigation": "Navigation (branding)",
       "navigation_collapsible": "Navigation Collapsible (menu)",
@@ -1163,7 +1163,7 @@
     "section": "page-title",
     "type": "boolean",
     "title": "Hide on Homepage",
-    "ai_description": "Hide the page title region on the homepage. Enable (1) when your homepage has its own hero/banner — avoids redundant Home title. Disable (0) if homepage needs the title region for branding.",
+    "ai_description": "Hide the page title region on the homepage. Enable (1) when your homepage has its own hero/banner to avoid a redundant Home title. Disable (0) if homepage needs the title region for branding.",
     "default": 1
   },
   "page_title_align": {
@@ -1206,7 +1206,7 @@
     "section": "page-title",
     "type": "radios",
     "title": "Animation",
-    "ai_description": "Entrance animation when the page title appears on load. 0=no animation (clean, professional). fade-in-dxpr=gentle fade (subtle). bounce-in-down-dxpr=bounces into view (playful). fade-in-up-dxpr=slides up and fades in (modern). Use sparingly — no animation is often most professional.",
+    "ai_description": "Entrance animation when the page title appears on load. 0=no animation (clean, professional). fade-in-dxpr=gentle fade (subtle). bounce-in-down-dxpr=bounces into view (playful). fade-in-up-dxpr=slides up and fades in (modern). Use sparingly; no animation is often most professional.",
     "options": {
       "0": "No Animation",
       "bounce-dxpr": "Bounce",
@@ -1273,7 +1273,7 @@
     "section": "page-title",
     "type": "radios",
     "title": "Background Position",
-    "ai_description": "Anchor point for the page title background image. center_center=safe default. Adjust based on the image focal point — e.g., left_top if the subject is in the top-left corner.",
+    "ai_description": "Anchor point for the page title background image. center_center=safe default. Adjust based on the image focal point, e.g. left_top if the subject is in the top-left corner.",
     "options": {
       "center_center": "Center",
       "left_top": "Top left",
@@ -1333,7 +1333,7 @@
     "type": "range",
     "title": "Typography Scale Factor",
     "description": "This overrides advanced type controls.",
-    "ai_description": "Typographic scale ratio multiplied across heading sizes. 1.0=manual control (use individual h1-h4 sizes). 1.125=major second (subtle). 1.25=major third (balanced — most popular). 1.333=perfect fourth. 1.5=perfect fifth (dramatic). 1.618=golden ratio. When >1, overrides individual h1-h4 font sizes.",
+    "ai_description": "Typographic scale ratio multiplied across heading sizes. 1.0=manual control (use individual h1-h4 sizes). 1.125=major second (subtle). 1.25=major third (balanced, most popular). 1.333=perfect fourth. 1.5=perfect fifth (dramatic). 1.618=golden ratio. When >1, overrides individual h1-h4 font sizes.",
     "min": 1,
     "max": 2,
     "step": 0.01,

--- a/features/sooper-header/header-theme-settings.inc
+++ b/features/sooper-header/header-theme-settings.inc
@@ -51,7 +51,7 @@ function header_theme_settings(array &$form, $theme) {
       'logo_center_menu_right' => t('Logo Center, Menu Right'),
       'logo_right_menu_left' => t('Logo Right, Menu Left'),
     ],
-    '#ai_description' => 'Visual arrangement of logo and navigation. 0=logo left, menu right (standard business/corporate — most versatile). centered=logo stacked above centered menu (boutique, restaurant, elegant). centered_inline=logo centered between split menu halves (fashion, luxury). logo_left_menu_left=both left-aligned (editorial, news). logo_center_menu_left=logo centered, menu left (portfolio). logo_center_menu_right=logo centered, menu right (portfolio variant). logo_right_menu_left=logo right, menu left (RTL-friendly, unconventional).',
+    '#ai_description' => 'Visual arrangement of logo and navigation. 0=logo left, menu right (standard business/corporate, most versatile). centered=logo stacked above centered menu (boutique, restaurant, elegant). centered_inline=logo centered between split menu halves (fashion, luxury). logo_left_menu_left=both left-aligned (editorial, news). logo_center_menu_left=logo centered, menu left (portfolio). logo_center_menu_right=logo centered, menu right (portfolio variant). logo_right_menu_left=logo right, menu left (RTL-friendly, unconventional).',
   ];
 
   // Normalize header_style value - treat deprecated values as 'normal'.
@@ -65,7 +65,7 @@ function header_theme_settings(array &$form, $theme) {
     '#type' => 'radios',
     '#title' => t('Header Style'),
     '#description' => t('Overlay mode places the header over page content, allowing transparent backgrounds.'),
-    '#ai_description' => 'normal=standard header with its own background band above page content. overlay=header floats transparently over page content (hero images show through). Overlay is dramatic for landing pages with hero images — pair with reduced header_top_bg_opacity for glass effect.',
+    '#ai_description' => 'normal=standard header with its own background band above page content. overlay=header floats transparently over page content (hero images show through). Overlay is dramatic for landing pages with hero images; pair with reduced header_top_bg_opacity for glass effect.',
     '#default_value' => $header_style,
     '#options' => [
       'normal' => t('Normal'),
@@ -131,7 +131,7 @@ function header_theme_settings(array &$form, $theme) {
     '#title' => t('Sticky Header'),
     '#default_value' => ((theme_get_setting('header_top_sticky') !== NULL)) ? theme_get_setting('header_top_sticky') : FALSE,
     '#description' => t('Header appears after scrolling past a specified offset.'),
-    '#ai_description' => 'Requires header_top_fixed=true. When enabled, header shrinks/transforms after scrolling past header_top_height_sticky_offset. Creates a compact navigation that appears on scroll — common modern UX pattern. Configure the smaller size with header_top_height_scroll.',
+    '#ai_description' => 'Requires header_top_fixed=true. When enabled, header shrinks/transforms after scrolling past header_top_height_sticky_offset. Creates a compact navigation that appears on scroll, a common modern UX pattern. Configure the smaller size with header_top_height_scroll.',
     '#states' => [
       'visible' => [
         ':input[name="header_top_fixed"]' => ['checked' => TRUE],
@@ -664,7 +664,7 @@ function header_theme_settings(array &$form, $theme) {
       'bold' => t('Bold'),
       'lead' => t('Lead text'),
     ],
-    '#ai_description' => 'Font treatment for main menu links. (empty)=normal text. uppercase=ALL CAPS (strong, authoritative — corporate/tech). bold=heavier weight (prominent nav). lead=larger text (statement navigation). Uppercase + border hover creates a sophisticated nav pattern.',
+    '#ai_description' => 'Font treatment for main menu links. (empty)=normal text. uppercase=ALL CAPS (strong, authoritative, suits corporate/tech). bold=heavier weight (prominent nav). lead=larger text (statement navigation). Uppercase + border hover creates a sophisticated nav pattern.',
   ];
 
   $form['dxpr_theme_settings']['header']['menu']['menu_link_spacing'] = [
@@ -692,7 +692,7 @@ function header_theme_settings(array &$form, $theme) {
       'text' => t('Colored text'),
       'border' => t('Border'),
     ],
-    '#ai_description' => 'Visual feedback style when hovering over menu items. opacity=subtle fade (minimal, modern). background=colored fill behind item (corporate, clear). text=only text color changes (subtle). border=underline/overline effect (modern, editorial). Border hover is most popular in contemporary web design — configure with menu_border_* settings.',
+    '#ai_description' => 'Visual feedback style when hovering over menu items. opacity=subtle fade (minimal, modern). background=colored fill behind item (corporate, clear). text=only text color changes (subtle). border=underline/overline effect (modern, editorial). Border hover is most popular in contemporary web design; configure with menu_border_* settings.',
   ];
 
   $form['dxpr_theme_settings']['header']['menu']['menu_border'] = [

--- a/features/sooper-layout/layout-theme-settings.inc
+++ b/features/sooper-layout/layout-theme-settings.inc
@@ -26,7 +26,7 @@ function layout_theme_settings(array &$form, $theme) {
     '#title' => t('Boxed Layout'),
     '#default_value' => ((theme_get_setting('boxed_layout') !== NULL)) ? theme_get_setting('boxed_layout') : 1,
     '#description' => t('When enabled, all container backgrounds are constrained to a centered column instead of spanning full width.'),
-    '#ai_description' => 'Controls whether page backgrounds span full viewport or are contained in a centered column. 0 (off)=full-bleed backgrounds spanning entire browser width — modern, immersive, preferred for contemporary SaaS/portfolio/agency sites. 1 (on)=backgrounds constrained to centered box with visible page margins — traditional corporate/blog feel. Most modern designs use 0.',
+    '#ai_description' => 'Controls whether page backgrounds span full viewport or are contained in a centered column. 0 (off)=full-bleed backgrounds spanning entire browser width, modern and immersive, preferred for contemporary SaaS/portfolio/agency sites. 1 (on)=backgrounds constrained to centered box with visible page margins, traditional corporate/blog feel. Most modern designs use 0.',
   ];
 
   $form['dxpr_theme_settings']['layout']['sticky_footer'] = [
@@ -139,7 +139,7 @@ function layout_theme_settings(array &$form, $theme) {
     '#max' => 500,
     '#step' => 1,
     '#description' => t('Horizontal padding inside the container. Default is 30px.'),
-    '#ai_description' => 'Horizontal padding inside the main container — the breathing room between content and viewport edge. 15-20px=compact. 30px=standard. 50+px=generous whitespace for luxury/editorial feel.',
+    '#ai_description' => 'Horizontal padding inside the main container, i.e. the breathing room between content and viewport edge. 15-20px=compact. 30px=standard. 50+px=generous whitespace for luxury/editorial feel.',
     '#attributes' => [
       'class' => ['dxb-slider', 'gutter-container-range'],
       'data-dxb-slider' => TRUE,
@@ -349,7 +349,7 @@ function layout_theme_settings(array &$form, $theme) {
     '#multiple' => TRUE,
     '#title' => t('Hidden Regions'),
     '#description' => t('Selected regions will be hidden site-wide.'),
-    '#ai_description' => 'Permanently hide theme regions site-wide. Useful for simplifying layouts — e.g., hide sidebar_first and sidebar_second for a single-column design, hide page_title for a minimal look, hide secondary_header if not using a top bar.',
+    '#ai_description' => 'Permanently hide theme regions site-wide. Useful for simplifying layouts, e.g. hide sidebar_first and sidebar_second for a single-column design, hide page_title for a minimal look, hide secondary_header if not using a top bar.',
     '#default_value' => ((theme_get_setting('hidden_regions') !== NULL)) ? theme_get_setting('hidden_regions') : [],
     '#options' => [
       'navigation' => t('Navigation (branding)'),

--- a/features/sooper-page-title/page_title-theme-settings.inc
+++ b/features/sooper-page-title/page_title-theme-settings.inc
@@ -60,7 +60,7 @@ function page_title_theme_settings(array &$form, $theme) {
   $form['dxpr_theme_settings']['page_title']['page_title_home_hide'] = [
     '#type' => 'checkbox',
     '#title' => t('Hide on Homepage'),
-    '#ai_description' => 'Hide the page title region on the homepage. Enable (1) when your homepage has its own hero/banner — avoids redundant Home title. Disable (0) if homepage needs the title region for branding.',
+    '#ai_description' => 'Hide the page title region on the homepage. Enable (1) when your homepage has its own hero/banner to avoid a redundant Home title. Disable (0) if homepage needs the title region for branding.',
     '#default_value' => ((theme_get_setting('page_title_home_hide') !== NULL)) ? theme_get_setting('page_title_home_hide') : 1,
   ];
 
@@ -106,7 +106,7 @@ function page_title_theme_settings(array &$form, $theme) {
   $form['dxpr_theme_settings']['page_title']['page_title_animate'] = [
     '#type' => 'radios',
     '#title' => t('Animation'),
-    '#ai_description' => 'Entrance animation when the page title appears on load. 0=no animation (clean, professional). fade-in-dxpr=gentle fade (subtle). bounce-in-down-dxpr=bounces into view (playful). fade-in-up-dxpr=slides up and fades in (modern). Use sparingly — no animation is often most professional.',
+    '#ai_description' => 'Entrance animation when the page title appears on load. 0=no animation (clean, professional). fade-in-dxpr=gentle fade (subtle). bounce-in-down-dxpr=bounces into view (playful). fade-in-up-dxpr=slides up and fades in (modern). Use sparingly; no animation is often most professional.',
     '#default_value' => ((theme_get_setting('page_title_animate') !== NULL)) ? theme_get_setting('page_title_animate') : '0',
     '#options' => [
       '0' => t('No Animation'),
@@ -188,7 +188,7 @@ function page_title_theme_settings(array &$form, $theme) {
   $form['dxpr_theme_settings']['page_title']['background']['page_title_image_position'] = [
     '#type' => 'radios',
     '#title' => t('Background Position'),
-    '#ai_description' => 'Anchor point for the page title background image. center_center=safe default. Adjust based on the image focal point — e.g., left_top if the subject is in the top-left corner.',
+    '#ai_description' => 'Anchor point for the page title background image. center_center=safe default. Adjust based on the image focal point, e.g. left_top if the subject is in the top-left corner.',
     '#default_value' => ((theme_get_setting('page_title_image_position') !== NULL)) ? theme_get_setting('page_title_image_position') : 'center_center',
     '#options' => [
       'center_center' => t('Center'),

--- a/features/sooper-typography/typography-theme-settings.inc
+++ b/features/sooper-typography/typography-theme-settings.inc
@@ -86,7 +86,7 @@ function typography_theme_settings(array &$form, $theme) {
     '#type' => 'range',
     '#title' => t('Typography Scale Factor'),
     '#description' => t('This overrides advanced type controls.'),
-    '#ai_description' => 'Typographic scale ratio multiplied across heading sizes. 1.0=manual control (use individual h1-h4 sizes). 1.125=major second (subtle). 1.25=major third (balanced — most popular). 1.333=perfect fourth. 1.5=perfect fifth (dramatic). 1.618=golden ratio. When >1, overrides individual h1-h4 font sizes.',
+    '#ai_description' => 'Typographic scale ratio multiplied across heading sizes. 1.0=manual control (use individual h1-h4 sizes). 1.125=major second (subtle). 1.25=major third (balanced, most popular). 1.333=perfect fourth. 1.5=perfect fifth (dramatic). 1.618=golden ratio. When >1, overrides individual h1-h4 font sizes.',
     '#default_value' => ((theme_get_setting('scale_factor') !== NULL)) ? theme_get_setting('scale_factor') : 1,
     '#min' => 1,
     '#max' => 2,

--- a/scripts/generate-settings-schema.js
+++ b/scripts/generate-settings-schema.js
@@ -25,7 +25,7 @@ const SETTING_TYPES = new Set([
   'textfield', 'textarea', 'media_library',
 ]);
 
-// Keys to skip — UI-only form fields that don't store config.
+// Keys to skip: UI-only form fields that don't store config.
 const SKIP_KEYS = new Set([
   'ai_prompt', 'ai_font_prompt', 'ai_generate', 'ai_font_generate',
   'ai_error', 'ai_font_error',
@@ -336,7 +336,7 @@ const output = {
       type: 'Value type: boolean, range, radios, select, textfield, textarea, checkboxes, font, color, theme_color, media, path, serialized_palette',
       title: 'Short human label (shown in GUI)',
       description: 'Terse GUI description',
-      ai_description: 'Design-oriented guidance for AI agents — visual effects, value ranges for different styles, relationships',
+      ai_description: 'Design-oriented guidance for AI agents: visual effects, value ranges for different styles, relationships',
       options: 'Valid values for radios/select/checkboxes (object or _dynamic)',
       min: 'Minimum value for range type',
       max: 'Maximum value for range type',


### PR DESCRIPTION
## Summary
- Rephrase 14 em dashes across `#ai_description` strings in theme settings `.inc` files and `generate-settings-schema.js` to use commas, semicolons, or natural connectors
- Exclude the `fonts/` directory from both grep passes in `emdash-lint.yml` since it contains third-party license text (SIL Open Font License) that should not be modified

## Context
The emdash-lint workflow was failing on all PRs (including #810) because these violations existed on the `8.x` base branch.

## Test plan
- [ ] Verify emdash-lint CI check passes on this PR
- [ ] Re-run checks on #810 after merge to confirm it passes