### PR TITLE
Add maxlength to 255 on font selectors. Fixes: #821

### DIFF
--- a/features/sooper-fonts/fonts-theme-settings.inc
+++ b/features/sooper-fonts/fonts-theme-settings.inc
@@ -105,6 +105,7 @@ function fonts_theme_settings(array &$form, $theme) {
   $form['dxpr_theme_settings']['fonts']['body_font_face_selector'] = [
     '#type' => 'textfield',
     '#title' => t('CSS Selector'),
+    '#maxlength' => 255,
     '#ai_description' => 'CSS selector where the body font applies. Default body covers everything. Rarely needs changing unless you want body font only on specific elements.',
     '#default_value' => ((theme_get_setting('body_font_face_selector') !== NULL)) ? theme_get_setting('body_font_face_selector') : 'body',
   ];
@@ -120,6 +121,7 @@ function fonts_theme_settings(array &$form, $theme) {
   $form['dxpr_theme_settings']['fonts']['headings_font_face_selector'] = [
     '#type' => 'textfield',
     '#title' => t('CSS Selector'),
+    '#maxlength' => 255,
     '#ai_description' => 'CSS selector for headings font. Default covers h1-h6, display classes, labels, and page title. Extend to add custom heading classes.',
     '#default_value' => ((theme_get_setting('headings_font_face_selector') !== NULL)) ? theme_get_setting('headings_font_face_selector') : 'h1,.h1,h2,.h2,h3,.h3,h4,.h4,h5,.h5,h6,.h6,.display-1,.display-2,.display-3,.display-4,.display-5,.display-6,label,.field--label,.page-title',
   ];
@@ -135,6 +137,7 @@ function fonts_theme_settings(array &$form, $theme) {
   $form['dxpr_theme_settings']['fonts']['nav_font_face_selector'] = [
     '#type' => 'textfield',
     '#title' => t('CSS Selector'),
+    '#maxlength' => 255,
     '#ai_description' => 'CSS selector for navigation font. Default .dxpr-theme-header .nav targets the main menu.',
     '#default_value' => ((theme_get_setting('nav_font_face_selector') !== NULL)) ? theme_get_setting('nav_font_face_selector') : '.dxpr-theme-header .nav',
   ];
@@ -150,6 +153,7 @@ function fonts_theme_settings(array &$form, $theme) {
   $form['dxpr_theme_settings']['fonts']['sitename_font_face_selector'] = [
     '#type' => 'textfield',
     '#title' => t('CSS Selector'),
+    '#maxlength' => 255,
     '#ai_description' => 'CSS selector for site name font. Default covers .site-name and .navbar-brand.',
     '#default_value' => ((theme_get_setting('sitename_font_face_selector') !== NULL)) ? theme_get_setting('sitename_font_face_selector') : '.site-name, .navbar-brand',
   ];
@@ -165,6 +169,7 @@ function fonts_theme_settings(array &$form, $theme) {
   $form['dxpr_theme_settings']['fonts']['blockquote_font_face_selector'] = [
     '#type' => 'textfield',
     '#title' => t('CSS Selector'),
+    '#maxlength' => 255,
     '#ai_description' => 'CSS selector for blockquote font. Default covers blockquote and blockquote p elements.',
     '#default_value' => ((theme_get_setting('blockquote_font_face_selector') !== NULL)) ? theme_get_setting('blockquote_font_face_selector') : 'blockquote, blockquote p',
   ];


### PR DESCRIPTION
## Linked issues

- #821
- https://www.drupal.org/project/dxpr_theme/issues/3593878

## Solution

Drupal core textfields default to `#maxlength` 128. DXPR Theme's default `headings_font_face_selector` value is 139 characters, so saving theme settings fails with:
> CSS Selector cannot be longer than 128 characters but is currently 139 characters long.
This can happen even when changing unrelated settings (for example color palette values), because the entire theme settings form is validated on submit.
Set `#maxlength` to 255 on all five `*_font_face_selector` fields in `features/sooper-fonts/fonts-theme-settings.inc` so default and custom font CSS selectors can be saved without validation errors.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
