### PR TITLE
Replace drupal_flush_all_caches() with targeted invalidation

### DIFF
--- a/dxpr_theme_callbacks.inc
+++ b/dxpr_theme_callbacks.inc
@@ -114,7 +114,13 @@ function dxpr_theme_css_cache_build(string $theme) {
   // Clear the discovery cache for library definitions.
   \Drupal::cache('discovery')->invalidateAll();
   // Invalidate the library info cache.
-  \Drupal::service('library.discovery')->clearCachedDefinitions();
+  $library_discovery = \Drupal::service('library.discovery');
+  if (method_exists($library_discovery, 'clear')) {
+    $library_discovery->clear();
+  }
+  else {
+    $library_discovery->clearCachedDefinitions();
+  }
 }
 
 /**

--- a/dxpr_theme_callbacks.inc
+++ b/dxpr_theme_callbacks.inc
@@ -95,8 +95,22 @@ function dxpr_theme_css_cache_build(string $theme) {
   // Clear CSS/JS aggregated files.
   \Drupal::service('asset.css.collection_optimizer')->deleteAll();
   \Drupal::service('asset.js.collection_optimizer')->deleteAll();
+  // Reset the asset query string so browsers fetch fresh CSS/JS.
+  if (\Drupal::hasService('asset.query_string')) {
+    \Drupal::service('asset.query_string')->reset();
+  }
+  elseif (function_exists('_drupal_flush_css_js')) {
+    _drupal_flush_css_js();
+  }
   // Clear the render cache so pages pick up the new CSS.
   \Drupal::cache('render')->invalidateAll();
+  // Clear page-level caches so anonymous visitors get fresh responses.
+  if (\Drupal::hasService('cache.page')) {
+    \Drupal::cache('page')->invalidateAll();
+  }
+  if (\Drupal::hasService('cache.dynamic_page_cache')) {
+    \Drupal::cache('dynamic_page_cache')->invalidateAll();
+  }
   // Clear the discovery cache for library definitions.
   \Drupal::cache('discovery')->invalidateAll();
   // Invalidate the library info cache.

--- a/dxpr_theme_callbacks.inc
+++ b/dxpr_theme_callbacks.inc
@@ -92,10 +92,15 @@ function dxpr_theme_css_cache_build(string $theme) {
     \Drupal::logger('dxpr_theme')->error($message);
   }
 
-  // If the CSS & JS aggregation are enabled we need to clear the caches.
-  drupal_flush_all_caches();
+  // Clear CSS/JS aggregated files.
   \Drupal::service('asset.css.collection_optimizer')->deleteAll();
   \Drupal::service('asset.js.collection_optimizer')->deleteAll();
+  // Clear the render cache so pages pick up the new CSS.
+  \Drupal::cache('render')->invalidateAll();
+  // Clear the discovery cache for library definitions.
+  \Drupal::cache('discovery')->invalidateAll();
+  // Invalidate the library info cache.
+  \Drupal::service('library.discovery')->clearCachedDefinitions();
 }
 
 /**


### PR DESCRIPTION
## Linked issues

- Fix #826

## Solution

Replace `drupal_flush_all_caches()` with targeted cache invalidation that only clears CSS/JS aggregates, render cache, and library discovery cache. This avoids rebuilding the entire service container and router when only a CSS file has changed.

## Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Need to run update.php after code changes.
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.