### PR TITLE
Use Drupal 11.4 fonts key for bundled font preloading

### DIFF
--- a/dxpr_theme.libraries.yml
+++ b/dxpr_theme.libraries.yml
@@ -209,14 +209,16 @@ font.league-gothic:
     theme:
       fonts/leaguegothic/stylesheet.css: { minified: true }
   fonts:
-    - fonts/leaguegothic/league_gothic-webfont.woff
+    fonts/leaguegothic/league_gothic-webfont.woff:
+      preload: true
 
 font.chunk-five:
   css:
     theme:
       fonts/ChunkFive-fontfacekit/stylesheet.css: { minified: true }
   fonts:
-    - fonts/ChunkFive-fontfacekit/Chunkfive-webfont.woff
+    fonts/ChunkFive-fontfacekit/Chunkfive-webfont.woff:
+      preload: true
 
 enhanced-dropdowns:
   version: 1.x

--- a/dxpr_theme.libraries.yml
+++ b/dxpr_theme.libraries.yml
@@ -204,6 +204,20 @@ custom_animations:
     theme:
       css/animations-dxpr.css: {}
 
+font.league-gothic:
+  css:
+    theme:
+      fonts/leaguegothic/stylesheet.css: { minified: true }
+  fonts:
+    - fonts/leaguegothic/league_gothic-webfont.woff
+
+font.chunk-five:
+  css:
+    theme:
+      fonts/ChunkFive-fontfacekit/stylesheet.css: { minified: true }
+  fonts:
+    - fonts/ChunkFive-fontfacekit/Chunkfive-webfont.woff
+
 enhanced-dropdowns:
   version: 1.x
   js:

--- a/features/sooper-fonts/fonts-theme-settings-controller.inc
+++ b/features/sooper-fonts/fonts-theme-settings-controller.inc
@@ -41,7 +41,7 @@ function fonts_theme_settings_controller(array &$variables) {
     elseif (isset($dxpr_theme_font[0]) && $dxpr_theme_font[0] === '1') {
       $font_parts = explode('|', substr($dxpr_theme_font, 1));
       $font_family = $font_parts[2] ?? '';
-      if (isset($bundled_font_libraries[$font_family])) {
+      if (isset($bundled_font_libraries[$font_family]) && version_compare(\Drupal::VERSION, '11.4', '>=')) {
         $variables['#attached']['library'][] = $bundled_font_libraries[$font_family];
       }
       else {

--- a/features/sooper-fonts/fonts-theme-settings-controller.inc
+++ b/features/sooper-fonts/fonts-theme-settings-controller.inc
@@ -26,13 +26,27 @@ function fonts_theme_settings_controller(array &$variables) {
   $dxpr_theme_fonts = array_unique($dxpr_theme_fonts);
   $requested_google_fonts = [];
 
+  // Map bundled font families to their library definitions. These use the
+  // Drupal 11.4 'fonts' key for correct browser preloading.
+  $bundled_font_libraries = [
+    'LeagueGothicRegular' => 'dxpr_theme/font.league-gothic',
+    'ChunkFiveRegular' => 'dxpr_theme/font.chunk-five',
+  ];
+
   foreach ($dxpr_theme_fonts as $dxpr_theme_font) {
     if (isset($dxpr_theme_font[0]) && $dxpr_theme_font[0] === '0') {
       $dxpr_theme_font = trim(substr($dxpr_theme_font, 1), ':');
       $requested_google_fonts[] = $dxpr_theme_font;
     }
     elseif (isset($dxpr_theme_font[0]) && $dxpr_theme_font[0] === '1') {
-      _dxpr_theme_add_local_font($dxpr_theme_font, $variables);
+      $font_parts = explode('|', substr($dxpr_theme_font, 1));
+      $font_family = $font_parts[2] ?? '';
+      if (isset($bundled_font_libraries[$font_family])) {
+        $variables['#attached']['library'][] = $bundled_font_libraries[$font_family];
+      }
+      else {
+        _dxpr_theme_add_local_font($dxpr_theme_font, $variables);
+      }
     }
   }
 
@@ -247,6 +261,7 @@ function _dxpr_theme_add_local_font_preload_link($path, $font_family, array &$va
         'href' => '/' . dirname($path) . '/' . $font_families[$font_family]['url'],
         'as' => 'font',
         'type' => 'font/' . $font_families[$font_family]['format'],
+        'crossorigin' => 'anonymous',
       ],
     ];
     $variables['#attached']['html_head'][] = [


### PR DESCRIPTION
## Linked issues

- Fix #825

## Solution

Add Drupal 11.4 `fonts` key to library definitions for the bundled LeagueGothic and ChunkFive fonts, enabling correct browser preloading. Update the font loading code to attach these as standard Drupal libraries instead of injecting raw HTML head elements. Also fix the missing `crossorigin` attribute on preload links for user-uploaded fonts.

## Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Need to run update.php after code changes.
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.