### PR TITLE
Move custom active trail detection to client-side JavaScript

### DIFF
--- a/dxpr_theme.libraries.yml
+++ b/dxpr_theme.libraries.yml
@@ -214,3 +214,9 @@ enhanced-dropdowns:
       vendor/enhanced-dropdowns/dist/css/main.min.css: { minified: true }
   dependencies:
     - core/drupal
+
+active-trail:
+  js:
+    js/dist/dxpr-theme-active-trail.js: {}
+  dependencies:
+    - core/drupal

--- a/dxpr_theme.theme
+++ b/dxpr_theme.theme
@@ -277,9 +277,9 @@ function dxpr_theme_preprocess_page(&$variables) {
  * Implements hook_preprocess_menu().
  *
  * Attaches client-side active trail detection for Views-generated menu links
- * that core does not mark as active (core issue #3359511). This replaces
- * the previous server-side workaround that added a url.path cache context,
- * which caused the menu render cache to vary per URL path.
+ * that core does not mark as active (core issue #3359511). This removes the
+ * extra url.path cache context that the previous server-side workaround added;
+ * the core route.menu_active_trails cache context remains on menu blocks.
  *
  * @see https://www.drupal.org/project/dxpr_theme/issues/3553914
  * @see https://www.drupal.org/project/drupal/issues/3359511
@@ -307,7 +307,7 @@ function dxpr_theme_preprocess_menu(&$variables) {
  * @return bool
  *   TRUE if any item in this level or below is active.
  *
- * @deprecated in dxpr_theme:2.1.0 and is removed from dxpr_theme:3.0.0.
+ * @deprecated in dxpr_theme:8.2.0 and is removed from dxpr_theme:9.0.0.
  *   Active trail detection is now handled client-side via the active-trail
  *   library. This function is retained for backward compatibility but is no
  *   longer called by dxpr_theme_preprocess_menu().

--- a/dxpr_theme.theme
+++ b/dxpr_theme.theme
@@ -276,30 +276,32 @@ function dxpr_theme_preprocess_page(&$variables) {
 /**
  * Implements hook_preprocess_menu().
  *
- * Workaround for Drupal core regression where Views-generated menu links don't
- * receive proper active trail detection. Compares menu item URLs against the
- * current page path to set active states and propagates to parent items.
+ * Attaches client-side active trail detection for Views-generated menu links
+ * that core does not mark as active (core issue #3359511). This replaces
+ * the previous server-side workaround that added a url.path cache context,
+ * which caused the menu render cache to vary per URL path.
  *
  * @see https://www.drupal.org/project/dxpr_theme/issues/3553914
  * @see https://www.drupal.org/project/drupal/issues/3359511
- *
- * @todo Remove when core issue #3359511 is resolved.
  */
 function dxpr_theme_preprocess_menu(&$variables) {
   if (empty($variables['items'])) {
     return;
   }
 
-  $current_path = \Drupal::service('path.current')->getPath();
-  $is_front = \Drupal::service('path.matcher')->isFrontPage();
-  dxpr_theme_menu_set_active_trail($variables['items'], $current_path, $is_front);
-
-  // Ensure menu is cached per URL to prevent wrong active states.
-  $variables['#cache']['contexts'][] = 'url.path';
+  // Attach client-side active trail detection for edge cases (e.g.
+  // Views-generated menu links) not covered by core's built-in active trail.
+  $variables['#attached']['library'][] = 'dxpr_theme/active-trail';
 }
 
 /**
  * Recursively sets active trail on menu items by comparing URL paths.
+ *
+ * @deprecated in dxpr_theme:8.x-2.1.0 and is removed from dxpr_theme:9.x-1.0.0.
+ *   Active trail detection is now handled client-side via the active-trail
+ *   library. This function is retained for backward compatibility but is no
+ *   longer called by dxpr_theme_preprocess_menu().
+ * @see https://github.com/dxpr/dxpr_theme/issues/827
  *
  * @param array $items
  *   Menu items array (passed by reference).

--- a/dxpr_theme.theme
+++ b/dxpr_theme.theme
@@ -311,6 +311,7 @@ function dxpr_theme_preprocess_menu(&$variables) {
  *   Active trail detection is now handled client-side via the active-trail
  *   library. This function is retained for backward compatibility but is no
  *   longer called by dxpr_theme_preprocess_menu().
+ * @see https://www.drupal.org/project/dxpr_theme/issues/3509999
  */
 function dxpr_theme_menu_set_active_trail(array &$items, $current_path, $is_front) {
   $has_active = FALSE;

--- a/dxpr_theme.theme
+++ b/dxpr_theme.theme
@@ -297,12 +297,6 @@ function dxpr_theme_preprocess_menu(&$variables) {
 /**
  * Recursively sets active trail on menu items by comparing URL paths.
  *
- * @deprecated in dxpr_theme:8.x-2.1.0 and is removed from dxpr_theme:9.x-1.0.0.
- *   Active trail detection is now handled client-side via the active-trail
- *   library. This function is retained for backward compatibility but is no
- *   longer called by dxpr_theme_preprocess_menu().
- * @see https://github.com/dxpr/dxpr_theme/issues/827
- *
  * @param array $items
  *   Menu items array (passed by reference).
  * @param string $current_path
@@ -312,6 +306,11 @@ function dxpr_theme_preprocess_menu(&$variables) {
  *
  * @return bool
  *   TRUE if any item in this level or below is active.
+ *
+ * @deprecated in dxpr_theme:2.1.0 and is removed from dxpr_theme:3.0.0.
+ *   Active trail detection is now handled client-side via the active-trail
+ *   library. This function is retained for backward compatibility but is no
+ *   longer called by dxpr_theme_preprocess_menu().
  */
 function dxpr_theme_menu_set_active_trail(array &$items, $current_path, $is_front) {
   $has_active = FALSE;

--- a/js/dist/dxpr-theme-active-trail.js
+++ b/js/dist/dxpr-theme-active-trail.js
@@ -18,6 +18,10 @@
       const currentOrigin = window.location.origin;
       const menuLinks = document.querySelectorAll(".menu--main a[href]");
       menuLinks.forEach((link) => {
+        const rawHref = link.getAttribute("href");
+        if (!rawHref || rawHref.startsWith("#")) {
+          return;
+        }
         const linkUrl = new URL(link.href, currentOrigin);
         if (linkUrl.origin !== currentOrigin) {
           return;

--- a/js/dist/dxpr-theme-active-trail.js
+++ b/js/dist/dxpr-theme-active-trail.js
@@ -15,10 +15,14 @@
         return;
       }
       const currentPath = window.location.pathname;
+      const currentOrigin = window.location.origin;
       const menuLinks = document.querySelectorAll(".menu--main a[href]");
       menuLinks.forEach((link) => {
-        const linkPath = link.pathname;
-        if (linkPath === currentPath) {
+        const linkUrl = new URL(link.href, currentOrigin);
+        if (linkUrl.origin !== currentOrigin) {
+          return;
+        }
+        if (linkUrl.pathname === currentPath) {
           link.classList.add("is-active");
           let li = link.closest("li");
           while (li) {

--- a/js/dist/dxpr-theme-active-trail.js
+++ b/js/dist/dxpr-theme-active-trail.js
@@ -9,33 +9,30 @@
  */
 
 (function (Drupal) {
-  'use strict';
-
   Drupal.behaviors.dxprThemeActiveTrail = {
-    attach: function (context) {
+    attach(context) {
       if (context !== document) {
         return;
       }
-      var currentPath = window.location.pathname;
-      var menuLinks = document.querySelectorAll('.menu--main a[href]');
-      menuLinks.forEach(function (link) {
-        var linkPath = link.pathname;
+      const currentPath = window.location.pathname;
+      const menuLinks = document.querySelectorAll(".menu--main a[href]");
+      menuLinks.forEach((link) => {
+        const linkPath = link.pathname;
         if (linkPath === currentPath) {
-          link.classList.add('is-active');
-          var li = link.closest('li');
+          link.classList.add("is-active");
+          let li = link.closest("li");
           while (li) {
-            li.classList.add('menu-item--active-trail');
-            li.classList.add('active');
-            var parentUl = li.parentElement;
+            li.classList.add("menu-item--active-trail");
+            li.classList.add("active");
+            const parentUl = li.parentElement;
             if (parentUl) {
-              li = parentUl.closest('li');
+              li = parentUl.closest("li");
             } else {
               break;
             }
           }
         }
       });
-    }
+    },
   };
-
 })(Drupal);

--- a/js/dist/dxpr-theme-active-trail.js
+++ b/js/dist/dxpr-theme-active-trail.js
@@ -1,0 +1,41 @@
+/**
+ * @file
+ * Client-side active trail detection for menu links.
+ *
+ * Supplements core's built-in active trail with client-side detection so that
+ * the server-rendered menu does not need a url.path cache context. This covers
+ * edge cases such as Views-generated menu links that core does not mark as
+ * active (see https://www.drupal.org/project/drupal/issues/3359511).
+ */
+
+(function (Drupal) {
+  'use strict';
+
+  Drupal.behaviors.dxprThemeActiveTrail = {
+    attach: function (context) {
+      if (context !== document) {
+        return;
+      }
+      var currentPath = window.location.pathname;
+      var menuLinks = document.querySelectorAll('.menu--main a[href]');
+      menuLinks.forEach(function (link) {
+        var linkPath = link.pathname;
+        if (linkPath === currentPath) {
+          link.classList.add('is-active');
+          var li = link.closest('li');
+          while (li) {
+            li.classList.add('menu-item--active-trail');
+            li.classList.add('active');
+            var parentUl = li.parentElement;
+            if (parentUl) {
+              li = parentUl.closest('li');
+            } else {
+              break;
+            }
+          }
+        }
+      });
+    }
+  };
+
+})(Drupal);


### PR DESCRIPTION
## Linked issues

- Fix #827

## Solution

Remove the custom server-side active trail workaround that added `url.path` cache context to every menu render (causing the menu to be cached per-URL-path). Replace with a lightweight client-side JavaScript that detects the active trail by comparing menu link hrefs against the current URL. Core's built-in `in_active_trail` continues to work for standard menu links; the JS covers edge cases like Views-generated menu links (core issue #3359511).

This removes the extra `url.path` cache variation that dxpr_theme was adding. Core's `route.menu_active_trails:main` cache context remains on menu blocks, so the menu still varies by active trail (not by every URL path). This significantly reduces the number of cached menu renders: from one per URL to roughly one per distinct active trail.

## Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Need to run update.php after code changes.
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.