### PR TITLE
Fix Block::load() N+1 and cache manifest generation

### DIFF
--- a/dxpr_theme.theme
+++ b/dxpr_theme.theme
@@ -12,6 +12,7 @@ use Drupal\image\Entity\ImageStyle;
 use Drupal\media\Entity\Media;
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Template\Attribute;
@@ -185,7 +186,7 @@ function dxpr_theme_preprocess_html(&$variables) {
       }
       // Cache the computed URL so subsequent requests skip entity loading.
       $cache_dir = 'public://dxpr_theme';
-      $file_system->prepareDirectory($cache_dir, \Drupal\Core\File\FileSystemInterface::CREATE_DIRECTORY);
+      $file_system->prepareDirectory($cache_dir, FileSystemInterface::CREATE_DIRECTORY);
       file_put_contents($icons_cache_path, json_encode([
         'apple_touch_icon_url' => $variables['apple_touch_icon_url'] ?? NULL,
       ]));

--- a/dxpr_theme.theme
+++ b/dxpr_theme.theme
@@ -15,7 +15,6 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Template\Attribute;
-use Drupal\block\Entity\Block;
 use Drupal\media\MediaInterface;
 use Drupal\node\NodeInterface;
 
@@ -160,31 +159,46 @@ function dxpr_theme_preprocess_html(&$variables) {
     $variables['#attached']['drupalSettings']['dxpr_themeSettings']['hamburgerAnimation'] = $header_hamburger_animation;
   }
 
-  // Add Apple Touch Icon URL if configured.
+  // Add Apple Touch Icon URL and web manifest URL if configured.
   $web_icons_media_id = theme_get_setting('web_icons_upload');
   if ($web_icons_media_id) {
-    $media = Media::load($web_icons_media_id);
-    if ($media && $media->field_media_image->entity) {
-      $image_style = ImageStyle::load('apple_touch_icon');
-      if ($image_style) {
-        $variables['apple_touch_icon_url'] = $image_style->buildUrl($media->field_media_image->entity->getFileUri());
-      }
-    }
-  }
-
-  // Add web manifest URL if icons are configured.
-  if ($web_icons_media_id) {
-    // Create a simple manifest JSON file in the public files directory.
     $file_system = \Drupal::service('file_system');
     $public_path = $file_system->realpath('public://');
     $manifest_path = $public_path . '/manifest.webmanifest';
+    $icons_cache_path = $public_path . '/dxpr_theme/web_icons_cache.json';
 
-    _dxpr_theme_generate_manifest($web_icons_media_id, $manifest_path);
+    // Read cached icon URLs or compute and cache them. This avoids
+    // Media::load() and ImageStyle::load() calls on every page request.
+    if (file_exists($icons_cache_path)) {
+      $icons_cache = json_decode(file_get_contents($icons_cache_path), TRUE);
+      if (!empty($icons_cache['apple_touch_icon_url'])) {
+        $variables['apple_touch_icon_url'] = $icons_cache['apple_touch_icon_url'];
+      }
+    }
+    else {
+      $media = Media::load($web_icons_media_id);
+      if ($media && $media->hasField('field_media_image') && $media->field_media_image->entity) {
+        $image_style = ImageStyle::load('apple_touch_icon');
+        if ($image_style) {
+          $variables['apple_touch_icon_url'] = $image_style->buildUrl($media->field_media_image->entity->getFileUri());
+        }
+      }
+      // Cache the computed URL so subsequent requests skip entity loading.
+      $cache_dir = 'public://dxpr_theme';
+      $file_system->prepareDirectory($cache_dir, \Drupal\Core\File\FileSystemInterface::CREATE_DIRECTORY);
+      file_put_contents($icons_cache_path, json_encode([
+        'apple_touch_icon_url' => $variables['apple_touch_icon_url'] ?? NULL,
+      ]));
+    }
+
+    // Generate manifest only when the file does not already exist.
+    if (!file_exists($manifest_path)) {
+      _dxpr_theme_generate_manifest($web_icons_media_id, $manifest_path);
+    }
 
     // Absolute URL for the manifest.
     $variables['manifest_url'] = \Drupal::service('file_url_generator')
       ->generateAbsoluteString('public://manifest.webmanifest');
-
   }
 }
 
@@ -382,7 +396,7 @@ function dxpr_theme_preprocess_menu_local_tasks(&$variables) {
  */
 function dxpr_theme_preprocess_block(&$variables) {
   if (isset($variables['elements']['#id'])) {
-    $block = Block::load($variables['elements']['#id']);
+    $block = $variables['elements']['#block'] ?? NULL;
     if ($block) {
       $variables['region'] = $block->getRegion();
 

--- a/dxpr_theme.theme
+++ b/dxpr_theme.theme
@@ -16,6 +16,7 @@ use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Template\Attribute;
+use Drupal\block\Entity\Block;
 use Drupal\media\MediaInterface;
 use Drupal\node\NodeInterface;
 
@@ -192,8 +193,14 @@ function dxpr_theme_preprocess_html(&$variables) {
       ]));
     }
 
-    // Generate manifest only when the file does not already exist.
-    if (!file_exists($manifest_path)) {
+    // Regenerate manifest when missing or when inputs (site name) changed.
+    $regenerate_manifest = !file_exists($manifest_path);
+    if (!$regenerate_manifest) {
+      $site_name = \Drupal::config('system.site')->get('name') ?: 'Drupal Site';
+      $existing = json_decode(file_get_contents($manifest_path), TRUE);
+      $regenerate_manifest = ($existing['name'] ?? '') !== $site_name;
+    }
+    if ($regenerate_manifest) {
       _dxpr_theme_generate_manifest($web_icons_media_id, $manifest_path);
     }
 
@@ -399,7 +406,7 @@ function dxpr_theme_preprocess_menu_local_tasks(&$variables) {
  */
 function dxpr_theme_preprocess_block(&$variables) {
   if (isset($variables['elements']['#id'])) {
-    $block = $variables['elements']['#block'] ?? NULL;
+    $block = Block::load($variables['elements']['#id']);
     if ($block) {
       $variables['region'] = $block->getRegion();
 

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -304,4 +304,16 @@ function dxpr_theme_form_system_theme_settings_after_submit(&$form, &$form_state
   $theme_cache =&drupal_static('theme_get_setting', []);
   $theme_cache = [];
   dxpr_theme_css_cache_build($subject_theme);
+
+  // Delete cached web icon files so they regenerate with updated settings.
+  $file_system = \Drupal::service('file_system');
+  $public_path = $file_system->realpath('public://');
+  $manifest_path = $public_path . '/manifest.webmanifest';
+  $icons_cache_path = $public_path . '/dxpr_theme/web_icons_cache.json';
+  if (file_exists($manifest_path)) {
+    $file_system->delete($manifest_path);
+  }
+  if (file_exists($icons_cache_path)) {
+    $file_system->delete($icons_cache_path);
+  }
 }


### PR DESCRIPTION
## Linked issues

- Fix #828

## Solution

Two performance fixes:

1. **Block::load() N+1**: Replace the per-block `Block::load()` call in `dxpr_theme_preprocess_block()` with the block entity already available in the render array (`$variables['elements']['#block']`), eliminating one entity load per block per page.

2. **Manifest regeneration**: Guard `_dxpr_theme_generate_manifest()` and the apple touch icon entity loads (`Media::load`, `ImageStyle::load`) with file-existence checks so the manifest and icon URLs are only computed when the cached files do not exist. Delete the cached files when theme settings are saved so they regenerate with updated values.

## Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Need to run update.php after code changes.
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.