### PR TITLE
Fix dropdown menus hidden by FOUC CSS specificity regression (#835)

### DIFF
--- a/templates/html.html.twig
+++ b/templates/html.html.twig
@@ -85,7 +85,7 @@
     {% endif %}
 
     <css-placeholder token="{{ placeholder_token|raw }}">
-    <style>.dxpr-theme-header ul.dropdown-menu {display: none;}</style>
+    <style>.dxpr-theme-header ul.dropdown-menu:not(.show) {display: none;}</style>
     <js-placeholder token="{{ placeholder_token|raw }}">
   </head>
   <body{{ attributes.addClass(body_classes) }}>


### PR DESCRIPTION
## Linked issues

#835

https://www.drupal.org/project/dxpr_theme/issues/3610960

## Solution

The 8.1.3 FOUC rule `.dxpr-theme-header ul.dropdown-menu { display: none; }` has higher specificity than Bootstrap’s .dropdown-menu.show, so open dropdowns stay hidden.

Updated the inline FOUC style in `templates/html.html.twig` to `.dxpr-theme-header ul.dropdown-menu:not(.show) { display: none; }`, so closed menus still avoid FOUC while open menus can display.

## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
