### PR TITLE
Fix menu type Bold/Uppercase/Lead overridden by Bootstrap .nav-link (#839)

### DIFF
--- a/features/sooper-header/header-theme-settings-css.inc
+++ b/features/sooper-header/header-theme-settings-css.inc
@@ -128,7 +128,7 @@ function header_theme_settings_css(string $theme, string &$css, array $palette) 
         break;
     }
 
-    $css .= ".dxpr-theme-header .nav a,\n.dxpr-theme-header .nav span,\n.dxpr-theme-header .nav button {\n  ";
+    $css .= "#navbar.dxpr-theme-header .nav a,\n#navbar.dxpr-theme-header .nav span,\n#navbar.dxpr-theme-header .nav button {\n  ";
     $css .= "$menu_type_value\n";
     $css .= "}\n\n";
   }


### PR DESCRIPTION
## Linked issues

- #839

## Solution

Increased the specificity of the PHP-generated menu-type CSS selector in `features/sooper-header/header-theme-settings-css.inc` by scoping it under `#navbar`:

`.dxpr-theme-header .nav a` -> `#navbar.dxpr-theme-header .nav a`

This raises specificity from `0,2,1` to `1,1,1`, which beats Bootstrap 5's `.nav-link` rule (`0,1,0`) that was overriding Bold, Uppercase, and Lead menu type styles with `font-weight: var(--bs-nav-link-font-weight)` (default: 400).

### Release notes

**Menu type styles (Bold, Uppercase, Lead) now apply correctly to all top-level menu items.** Previously, Bootstrap's `.nav-link` base styles could override the menu type setting, causing inconsistent styling where some top-level items appeared bold and others did not. After this update, if you had the "Bold" menu type enabled but were not seeing bold text (due to the Bootstrap override), your menu items will now correctly appear bold. If this is not desired, change the "Menu type" setting in Appearance > DXPR Theme > Header > Menu Options.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/1.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [x] My code follows the coding standards and style of this project.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Need to run update.php after code changes
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.